### PR TITLE
fix: Disable source map generation during production build

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,4 +1,6 @@
+// import path, { dirname } from "node:path";
 import { type AppConfig } from "./type.js";
+// import { fileURLToPath } from "node:url";
 
 /**
  * Function to define the config for the app
@@ -179,3 +181,41 @@ export const resolvePath = (path: string) => {
 
   return path;
 }
+
+
+/**
+ * Asynchronously loads a module from a file path relative to the project root directory.
+ *
+ * This function checks the current environment (production or development) and adjusts the file path accordingly. It then resolves the file path to a valid URL format based on the operating system.
+ *
+ * @param filename - The name of the file to be loaded.
+ * @returns The loaded module.
+ */
+// export const loadAsyncFromRoot = async (filename: string) => {
+//   try {
+//     const isProduction = process.env.NODE_ENV === "production";
+//     let __pathToRoot = "";
+
+//     if (!isProduction) {
+//       __pathToRoot = process.cwd();
+// 		} else {
+//       __pathToRoot = path.join(process.cwd(), "./../../");
+// 		}
+
+//     const filePath = resolvePath(path.join(__pathToRoot, filename));
+
+//     const file = await import(`./${filePath}`);
+
+//     return file;
+//   } catch (error) {
+//     console.error(error);
+//     return {};
+//   }
+// }
+
+// export const getDirname = (url: string) => {
+// 	// Get directory name
+// 	const __dirname = dirname(fileURLToPath(url));
+
+//   return __dirname;
+// }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,12 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
-// Load rasengan config file
-// @ts-ignore
-import config from "./../../rasengan.config.js";
-
 import path from "node:path";
 
-// Extract vite config
-const { vite } = config;
+// Load config
+// @ts-ignore
+import config from "./../../rasengan.config.js";
+// import { config } from "./AppEntry";
 
 // Getting root path
 let __pathToRoot = "";
@@ -41,6 +39,9 @@ export default defineConfig(async ({ command, mode }: any) => {
 		__pathToRoot = path.join(process.cwd(), "./../../");
 	}
 
+	// Extract vite config
+	const { vite } = config;
+
 	return {
 		// Define env
 		define: {
@@ -59,7 +60,8 @@ export default defineConfig(async ({ command, mode }: any) => {
 
 		// Build options
 		build: {
-			sourcemap: true,
+			sourcemap: mode === "development" ? true : false,
+			minify: "esbuild",
 			rollupOptions: {
 				input: "./lib/esm/entries/entry-client.js",
 				output: {


### PR DESCRIPTION
## Bug fixed

- Disable the source map generation in production mode to avoid sharing the source code that could be access via a scrapping tools