### PR TITLE
fix: Fixing build error for vercel when peers deps issue are encountered

### DIFF
--- a/packages/rasengan-vercel/index.ts
+++ b/packages/rasengan-vercel/index.ts
@@ -1,10 +1,9 @@
 import { resolveBuildOptions } from 'rasengan/server';
 import { AdapterConfig, AdapterOptions, Adapters } from 'rasengan/plugin';
-import { AppConfig } from 'rasengan';
+import { OptimizedAppConfig } from 'rasengan';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import fsSync from 'node:fs';
-import { execa } from 'execa';
 
 interface VercelBuildOptions {
   buildDirectory: string;
@@ -41,7 +40,7 @@ const checkVercelDirectory = async (vercelBuildOptions: VercelBuildOptions) => {
   }
 };
 
-const generateVercelDirectory = async (config: { ssr: AppConfig['ssr'] }) => {
+const generateVercelDirectory = async (config: OptimizedAppConfig) => {
   const vercelBuildOptions = getVercelBuildOptions();
 
   // Check if the .vercel directory exists
@@ -96,7 +95,7 @@ const generateVercelDirectory = async (config: { ssr: AppConfig['ssr'] }) => {
   }
 };
 
-const generateVercelConfigFile = async (config: { ssr: AppConfig['ssr'] }) => {
+const generateVercelConfigFile = async (config: OptimizedAppConfig) => {
   const vercelBuildOptions = getVercelBuildOptions();
 
   // Default Vercel configuration
@@ -231,50 +230,25 @@ const generateServerlessHandler = async () => {
   );
 };
 
-const generatePackageJson = async () => {
+const copyNodeModules = async () => {
   const vercelBuildOptions = getVercelBuildOptions();
 
-  // Load the package.json from the project root
-  const packageJsonPath = path.resolve('package.json');
-  const packageJsonContent = await fs.readFile(packageJsonPath, 'utf8');
-  const packageJsonData = JSON.parse(packageJsonContent);
+  console.log('Copying node_modules for serverless function');
 
-  // Default Vercel package.json
-  const packageJson = {
-    type: 'module',
-    dependencies: {
-      ...packageJsonData.dependencies,
-      express: '^4.17.1',
-      compression: '^1.7.5',
-    },
-  };
-
-  // Write the package.json to the .vercel/output/package.json file
-  await fs.writeFile(
+  // Copy the node_modules folder from the project root to .vercel/output/functions/index.func/server/node_modules
+  await fs.cp(
+    path.posix.join(process.cwd(), 'node_modules'),
     path.posix.join(
       vercelBuildOptions.buildDirectory,
       vercelBuildOptions.functionsDirectory,
-      'package.json'
+      vercelBuildOptions.serverDirectory,
+      'node_modules'
     ),
-    JSON.stringify(packageJson, null, 2)
+    { recursive: true }
   );
 };
 
-const runInstall = async () => {
-  const vercelBuildOptions = getVercelBuildOptions();
-
-  console.log('Running npm install for serverless function');
-
-  // Run npm install in the .vercel/output/functions/index.func directory
-  execa('npm', ['i', '--force'], {
-    cwd: path.posix.join(
-      vercelBuildOptions.buildDirectory,
-      vercelBuildOptions.functionsDirectory
-    ),
-  });
-};
-
-const copyStaticFiles = async (config: { ssr: AppConfig['ssr'] }) => {
+const copyStaticFiles = async (config: OptimizedAppConfig) => {
   const vercelBuildOptions = getVercelBuildOptions();
   const buildOptions = resolveBuildOptions({});
 
@@ -355,12 +329,12 @@ const loadRasenganConfig = async () => {
   const configData = await fs.readFile(configPath, 'utf8');
 
   // Return the configuration
-  return JSON.parse(configData);
+  return JSON.parse(configData) as OptimizedAppConfig;
 };
 
 const prepare = async (options: AdapterOptions) => {
   // Load the Rasengan configuration file
-  const config = (await loadRasenganConfig()) as { ssr: AppConfig['ssr'] };
+  const config = await loadRasenganConfig();
 
   // Prepare the Vercel directory
   await generateVercelDirectory(config);
@@ -381,11 +355,8 @@ const prepare = async (options: AdapterOptions) => {
     // Prepare the serverless handler
     await generateServerlessHandler();
 
-    // Prepare the package.json
-    await generatePackageJson();
-
-    // Run npm install
-    await runInstall();
+    // Copy the node_modules folder to the Vercel directory
+    await copyNodeModules();
   }
 };
 

--- a/packages/rasengan/src/core/config/type.ts
+++ b/packages/rasengan/src/core/config/type.ts
@@ -1,4 +1,5 @@
 import type * as Vite from 'vite';
+import { BuildOptions } from '../../server/build';
 
 export interface ServerConfig {
   /**
@@ -67,6 +68,12 @@ export type AppConfig = {
    * Configure the app
    */
   redirects?: () => Promise<Redirect[]>;
+};
+
+export type OptimizedAppConfig = {
+  ssr?: AppConfig['ssr'];
+  redirects: Redirect[];
+  buildOptions: BuildOptions;
 };
 
 export type AppConfigFunction = () => AppConfig;

--- a/packages/rasengan/src/core/config/vite/defaults.ts
+++ b/packages/rasengan/src/core/config/vite/defaults.ts
@@ -78,7 +78,6 @@ export const createDefaultViteConfig = (
               'app.router': './src/app/app.router',
               main: './src/main',
               template: './src/template',
-              config: './rasengan.config.js',
             },
           },
           ssrEmitAssets: false,

--- a/packages/rasengan/src/core/plugins/index.ts
+++ b/packages/rasengan/src/core/plugins/index.ts
@@ -213,6 +213,12 @@ export function rasengan({
         }
 
         // Generate a config.json file into the dist/client/assets or dist/assets
+        const minimizedConfig = {
+          buildOptions,
+          ssr: config.ssr,
+          redirects: await config.redirects(),
+        };
+
         fs.writeFileSync(
           path.posix.join(
             process.cwd(),
@@ -221,10 +227,7 @@ export function rasengan({
             buildOptions.assetPathDirectory,
             'config.json'
           ),
-          JSON.stringify({
-            buildOptions,
-            ssr: config.ssr,
-          }),
+          JSON.stringify(minimizedConfig),
           'utf-8'
         );
 

--- a/packages/rasengan/src/index.ts
+++ b/packages/rasengan/src/index.ts
@@ -10,6 +10,7 @@ export type {
   AppConfig,
   AppConfigFunction,
   AppConfigFunctionAsync,
+  OptimizedAppConfig,
 } from './core/config/type.js';
 export type { AppProps } from './core/index.js';
 export type * from './server/build/manifest.js';

--- a/playground/rasengan-v1-test/rasengan.config.js
+++ b/playground/rasengan-v1-test/rasengan.config.js
@@ -16,5 +16,14 @@ export default defineConfig(async () => {
         }),
       ],
     },
+
+    redirects: async () => {
+      return [
+        {
+          source: '/',
+          destination: '/docs',
+        },
+      ];
+    },
   };
 });


### PR DESCRIPTION
## Related Issue

The issue is about build process for vercel platform only in SSR mode. When there was a peer deps mismatch, it was not possible to have the app working on vercel anymore, because the installation process of dependancies is interrupted due to peer deps mismatch.

The first solution was to force the installation with `--force` option without the developer agreement, but can add more issue in prod.

## 🚀 Type of Change

<!-- Select the type of change your PR introduces. -->

- [ ] 📖 Documentation (Updates to README, API docs, or comments)
- [x] 🐞 Bug Fix (Non-breaking fix for an issue)
- [ ] ⚡ Performance (Optimizations for faster execution)
- [ ] ✨ Feature (New functionality without breaking changes)
- [x] 🔧 Refactor (Code improvements without changing behavior)
- [x] 🧹 Chore (Build process, tooling, dependencies)
- [ ] ⚠️ Breaking Change (Modifications that impact existing usage)

## 📜 Description

The solution I have opted for is:

- No more installation for serverless function while hosting the app in SSR mode on vercel
- Instead of installing again the deps, I decided to copy the actual node_modules into the serverless function directory
- I've also optimized the config file during build process

## ✅ Checklist

<!-- Ensure these are checked before requesting review. -->

- [ ] I have linked a related issue or discussion.
- [ ] I have updated documentation if needed.
- [x] I have tested the changes in a real project.
- [ ] I have added tests or confirmed that existing tests pass.
