### PR TITLE
feat(sitemap): add @rasenganjs/sitemap package for static sitemap generation (RFC-0011)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,10 @@ static/          # Pre-rendered HTML files (if prerendering)
 .vercel/output/  # Vercel deployment output (if Vercel adapter)
 ```
 
+### Writing style: no em-dash in generated interface text
+
+When generating text that will be displayed in any interface (docs-v2 MDX content, UI copy/labels, README content, generated markdown, etc.), never use the "—" (em-dash) character. Use a comma, period, colon, or parentheses instead, whichever reads most naturally. This applies to newly written content and to edits of existing content that already contains one.
+
 ---
 
 ## 8. Scripts (`/scripts/`)

--- a/apps/docs-v2/package.json
+++ b/apps/docs-v2/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "rasengan dev",
-    "build": "rasengan build",
+    "build": "rasengan build && rasengan-sitemap",
     "serve": "rasengan-serve ./dist"
   },
   "dependencies": {
@@ -13,6 +13,7 @@
     "@rasenganjs/kage-demo": "1.0.1",
     "@rasenganjs/mdx": "1.2.2",
     "@rasenganjs/serve": "beta",
+    "@rasenganjs/sitemap": "workspace:*",
     "@rasenganjs/theme": "^1.1.0",
     "@rasenganjs/vercel": "beta",
     "@tailwindcss/vite": "^4.*",

--- a/apps/docs-v2/rasengan-sitemap.config.js
+++ b/apps/docs-v2/rasengan-sitemap.config.js
@@ -1,0 +1,8 @@
+// rasengan-sitemap.config.js
+import { defineSitemapConfig } from '@rasenganjs/sitemap';
+
+export default defineSitemapConfig({
+  siteUrl: 'https://rasengan.dev',
+  changefreq: 'weekly',
+  priority: 0.7,
+});

--- a/apps/docs-v2/src/app/_routes/(documentation)/layout.tsx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/layout.tsx
@@ -3,16 +3,18 @@ import DocsNavTabs from '@/components/common/layout/nav-tabs';
 import { Outlet, LayoutComponent } from 'rasengan';
 import SidebarNavigation from '@/components/common/layout/sidebar';
 import Footer from '@/components/common/layout/footer';
-import { useState, useRef } from 'react';
+import { useRef } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import { twMerge } from 'tailwind-merge';
 import { ScrollRestoration } from '@/components/common/molecules/scroll-restoration';
 import { cn } from '@/lib/utils';
+import { useNavigationStore } from '@/store/navigation';
 
 const DocsLayout: LayoutComponent = () => {
   const targetRef = useRef<HTMLElement>(null);
 
-  const [navigationOpen, setNavigationOpen] = useState(false);
+  const { isOpen: navigationOpen, close: closeNavigation } =
+    useNavigationStore();
 
   return (
     <section
@@ -38,28 +40,38 @@ const DocsLayout: LayoutComponent = () => {
         <div className="w-full relative flex">
           <SidebarNavigation className="hidden lg:flex h-auto" />
 
-          <motion.div
-            initial={{ x: '-100%' }}
-            animate={{ x: navigationOpen ? 0 : '-100%' }}
-            transition={{ duration: 0.2 }}
-            className={twMerge(
-              'z-40 fixed top-[110px] bg-background block lg:hidden'
+          {/* Mounted only while open (AnimatePresence handles the exit
+              animation), matching the overlay right below, instead of
+              always rendering a 280px drawer off-screen at -100%. */}
+          <AnimatePresence>
+            {navigationOpen && (
+              <motion.div
+                key="mobile-sidebar"
+                initial={{ x: '-100%' }}
+                animate={{ x: '0%' }}
+                exit={{ x: '-100%' }}
+                transition={{ duration: 0.2 }}
+                className={twMerge(
+                  'z-40 fixed top-[110px] bg-background block lg:hidden'
+                )}
+              >
+                <SidebarNavigation
+                  className="h-auto"
+                  onClose={() => closeNavigation()}
+                />
+              </motion.div>
             )}
-          >
-            <SidebarNavigation
-              className="h-auto"
-              onClose={() => setNavigationOpen(false)}
-            />
-          </motion.div>
+          </AnimatePresence>
 
           <AnimatePresence>
             {navigationOpen && (
               <motion.div
+                key="mobile-sidebar-overlay"
                 initial={{ opacity: 0 }}
-                animate={{ opacity: navigationOpen ? 1 : 0 }}
+                animate={{ opacity: 1 }}
                 exit={{ opacity: 0 }}
                 transition={{ duration: 0.2 }}
-                onClick={() => setNavigationOpen(false)}
+                onClick={() => closeNavigation()}
                 className="z-20 fixed top-0 left-0 w-full h-full bg-background/90 block lg:hidden"
               />
             )}

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/create-rasengan.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/create-rasengan.page.mdx
@@ -151,26 +151,17 @@ npx create-rasengan@latest my-app --chidori
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/drizzle.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/drizzle.page.mdx
@@ -107,26 +107,17 @@ For the complete API (`DrizzleModuleOptions`, `DataSource`, and how this fits in
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/i18n.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/i18n.page.mdx
@@ -202,27 +202,17 @@ export default Navbar;
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/image.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/image.page.mdx
@@ -106,26 +106,17 @@ import Image from '@rasenganjs/image';
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/io.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/io.page.mdx
@@ -207,26 +207,17 @@ Returns a typed emit function for sending events to the server.
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/kage-demo.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/kage-demo.page.mdx
@@ -215,27 +215,17 @@ But feel free to style them as you want to meet the system design of your applic
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/kurama.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/kurama.page.mdx
@@ -207,27 +207,17 @@ That’s the power of Kurama.
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/mdx.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/mdx.page.mdx
@@ -594,27 +594,17 @@ export default defineConfig({
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/netlify.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/netlify.page.mdx
@@ -69,27 +69,17 @@ Alternatively, you can link your GitHub repository to Netlify, and it will autom
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/queue.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/queue.page.mdx
@@ -114,26 +114,17 @@ For the complete API (retry semantics, dead-letter handling, `ProcessOptions`, a
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/serve.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/serve.page.mdx
@@ -107,27 +107,17 @@ npm run serve
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/sitemap.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/sitemap.page.mdx
@@ -1,0 +1,122 @@
+---
+metadata:
+  title: Rasengan Sitemap Package - Modules | Packages | Rasengan.js
+  description: "Documentation for the Rasengan Sitemap package: automatic sitemap.xml generation for Rasengan frontend apps."
+toc: true
+---
+
+<span className="text-[12px] font-mono-regular text-foreground/60">
+  PACKAGES
+</span>
+# Rasengan Sitemap
+
+`@rasenganjs/sitemap` generates a spec-compliant `sitemap.xml` for a [Rasengan](/docs/getting-started/introduction) app, in `ssr` or `prerender` (SSG) mode. It's a standalone CLI that runs as a separate step after `rasengan build`, not a Vite plugin, so it always sees the final, complete build output.
+
+<Note title="Frontend only" type="info">
+  This package targets the `rasengan` frontend framework exclusively. Futon
+  and [Rasengan Server](/docs/server/getting-started/introduction) are backend
+  frameworks with no concept of a "page," so a sitemap doesn't apply to them.
+  `_api/` routes are JSON endpoints and are never included, they're excluded
+  by construction rather than by a filter.
+</Note>
+
+## Installation
+
+```bash title="Terminal"
+npm install -D @rasenganjs/sitemap
+```
+
+## Usage
+
+Create a `rasengan-sitemap.config.js` at your project root:
+
+```ts title="rasengan-sitemap.config.js" showLineNumbers
+import { defineSitemapConfig } from '@rasenganjs/sitemap';
+
+export default defineSitemapConfig({
+  siteUrl: 'https://your-site.com', // required
+  changefreq: 'weekly', // optional
+  priority: 0.7, // optional
+  exclude: ['/admin/*'], // optional, glob against the route path
+  generateRobotsTxt: false, // optional, off by default
+});
+```
+
+Then run the CLI after your build:
+
+```bash title="Terminal"
+rasengan build && rasengan-sitemap
+```
+
+Or wire it into your `package.json`:
+
+```json title="package.json" showLineNumbers
+{
+  "scripts": {
+    "build": "rasengan build && rasengan-sitemap"
+  }
+}
+```
+
+`rasengan-sitemap` reads the build's `config.json` to know which mode the app was built in, then writes `sitemap.xml` into the same directory the app actually produced:
+
+- `prerender: true` → `static/sitemap.xml`
+- `ssr: true`, `prerender: false` → `dist/client/sitemap.xml`
+
+<Note title="Pure SPA builds are not supported yet" type="warning">
+  A `ssr: false, prerender: false` build produces no server-rendered route
+  bundle, so there's nothing for `rasengan-sitemap` to enumerate routes from.
+  Set `ssr: true` in `rasengan.config.js`, run `rasengan build`, then
+  `rasengan-sitemap`, the route tree is identical either way, only the
+  rendering strategy differs.
+</Note>
+
+## What Gets Excluded Automatically
+
+- The catch-all `*`/404 route.
+- `_api/` routes, dispatched through a separate router and never part of the page route tree.
+- Any route matching a `source` in your `rasengan.config.js`'s `redirects()`, a URL that immediately redirects elsewhere is a low-quality sitemap entry.
+- Anything matching your own `exclude` glob patterns.
+
+## Per-Route Overrides
+
+For control beyond the static `changefreq`/`priority` defaults, use `transform`:
+
+```ts title="rasengan-sitemap.config.js" showLineNumbers
+import { defineSitemapConfig } from '@rasenganjs/sitemap';
+
+export default defineSitemapConfig({
+  siteUrl: 'https://your-site.com',
+  transform: async (path) => ({
+    loc: path,
+    changefreq: path === '/' ? 'daily' : 'weekly',
+    priority: path === '/' ? 1.0 : 0.7,
+  }),
+});
+```
+
+## `robots.txt` Generation
+
+Set `generateRobotsTxt: true` to also write a minimal `robots.txt` alongside `sitemap.xml`, with a `Sitemap:` line pointing at it. Off by default, so it never silently overwrites a hand-written `robots.txt`.
+
+## Community
+
+Join the Rasengan.js community to get support, ask questions, and share your projects:
+
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
+    target="_blank"
+    rel="noopener noreferrer"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
+    target="_blank"
+    rel="noopener noreferrer"
+  >Linkedin</Link> : Follow the company page.
+
+Let's build something amazing with Rasengan.js! 🚀
+
+## License
+
+This package is [MIT licensed](https://github.com/rasengan-dev/rasenganjs/blob/main/LICENSE).

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/theme.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/theme.page.mdx
@@ -178,27 +178,17 @@ export default function Template({ Head, Body, Script }) {
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/vercel.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/vercel.page.mdx
@@ -61,27 +61,17 @@ Alternatively, you can link your GitHub repository to Vercel, and it will automa
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-  {/* - **Discord** – Chat with the community. */}
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/ws.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/(modules)/ws.page.mdx
@@ -94,26 +94,17 @@ For the complete API (`GatewayClient`, `GatewayServer`, heartbeat configuration,
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/(documentation)/packages/index.page.mdx
+++ b/apps/docs-v2/src/app/_routes/(documentation)/packages/index.page.mdx
@@ -152,26 +152,17 @@ Rasengan.js is a powerful and flexible React framework designed to enhance devel
 
 Join the Rasengan.js community to get support, ask questions, and share your projects:
 
-- <a
-    href="https://github.com/rasengan-dev/rasenganjs/discussions"
+- <Link
+    to="https://github.com/rasengan-dev/rasenganjs/discussions"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    GitHub Discussions
-  </a>
-  – Ask questions and share ideas.
-- <a href="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">
-    X (Twitter)
-  </a>
-  – Stay updated with the latest news.
-- <a
-    href="https://www.linkedin.com/company/rasenganjs/"
+  >GitHub Discussions</Link> : Ask questions and share ideas.
+- <Link to="https://x.com/rasenganjs" target="_blank" rel="noopener noreferrer">X (Twitter)</Link> : Stay updated with the latest news.
+- <Link
+    to="https://www.linkedin.com/company/rasenganjs/"
     target="_blank"
     rel="noopener noreferrer"
-  >
-    Linkedin
-  </a>
-  – Follow the company page.
+  >Linkedin</Link> : Follow the company page.
 
 Let's build something amazing with Rasengan.js! 🚀
 

--- a/apps/docs-v2/src/app/_routes/blog/rasengan-futon-and-server.page.mdx
+++ b/apps/docs-v2/src/app/_routes/blog/rasengan-futon-and-server.page.mdx
@@ -1,49 +1,49 @@
 ---
 metadata:
   title: 'Introducing Futon and Rasengan Server'
-  description: Rasengan.js grows beyond the frontend — meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.
+  description: 'Rasengan.js grows beyond the frontend: meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.'
   openGraph:
     title: 'Introducing Futon and Rasengan Server'
-    description: Rasengan.js grows beyond the frontend — meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.
+    description: 'Rasengan.js grows beyond the frontend: meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.'
     url: 'https://rasengan.dev'
     image: 'https://rasengan.dev/assets/blog/rasengan-futon-and-server.png'
   twitter:
     title: 'Introducing Futon and Rasengan Server'
-    description: Rasengan.js grows beyond the frontend — meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.
+    description: 'Rasengan.js grows beyond the frontend: meet Futon, a WinterCG-compatible HTTP runtime, and Rasengan Server, a NestJS-inspired backend framework built on top of it.'
     image: 'https://rasengan.dev/assets/blog/rasengan-futon-and-server.png'
 ---
 
 <BlogDetailsHeader />
 
-Rasengan.js has always been a frontend meta-framework. Today that changes: we're expanding the ecosystem beyond the browser with two new frameworks in public beta —
+Rasengan.js has always been a frontend meta-framework. Today that changes: we're expanding the ecosystem beyond the browser with two new frameworks in public beta:
 
-- [**Futon**](#introducing-futon) — a zero-dependency, WinterCG-compatible HTTP runtime
-- [**Rasengan Server**](#introducing-rasengan-server) — a Controller-based backend framework built on top of Futon
+- [**Futon**](#introducing-futon): a zero-dependency, WinterCG-compatible HTTP runtime
+- [**Rasengan Server**](#introducing-rasengan-server): a Controller-based backend framework built on top of Futon
 
-Same conventions, same care about developer experience, now covering the full stack — frontend, HTTP runtime, and backend.
+Same conventions, same care about developer experience, now covering the full stack: frontend, HTTP runtime, and backend.
 
 <br />
 
 ## Introducing Futon
 
-`@rasenganjs/futon` is the HTTP engine underneath Rasengan Server — and it works perfectly well on its own. If you've ever reached for Express or Hono to build a small API, Futon is built for that same job, with a Koa-style middleware model and a runtime-agnostic core that runs unmodified on **Node**, **Bun**, and **Cloudflare Workers** (or any WinterCG-compatible host).
+`@rasenganjs/futon` is the HTTP engine underneath Rasengan Server and it works perfectly well on its own. If you've ever reached for Express or Hono to build a small API, Futon is built for that same job, with a Koa-style middleware model and a runtime-agnostic core that runs unmodified on **Node**, **Bun**, and **Cloudflare Workers** (or any WinterCG-compatible host).
 
 ### What's inside
 
-- **Middleware onion model** — familiar `async (ctx, next) => {}` composition, with `compose()` for chaining
-- **A radix-tree router** — static, dynamic (`:id`), optional, and wildcard segments, with `router.group()` for scoped prefixes and shared middleware
-- **A per-request `Context`** — request/response helpers, cookies, and a typed `ctx.query`/`ctx.params`
-- **Built-in middleware** — CORS, logging, compression, basic/bearer auth, and body parsing, ready to import
-- **`fileUpload()`** — Multer-style multipart uploads, with `MemoryStorage`, `DiskStorage`, or a custom storage engine
-- **Hooks** — observe the request lifecycle without writing middleware
-- **Adapters** — `@rasenganjs/runtime` ships Node, Bun, and Workerd adapters, plus bridges to mount Futon inside an existing **Express** app or deploy it to any **WinterCG**-compatible platform
+- **Middleware onion model**: familiar `async (ctx, next) => {}` composition, with `compose()` for chaining
+- **A radix-tree router**: static, dynamic (`:id`), optional, and wildcard segments, with `router.group()` for scoped prefixes and shared middleware
+- **A per-request `Context`**: request/response helpers, cookies, and a typed `ctx.query`/`ctx.params`
+- **Built-in middleware**: CORS, logging, compression, basic/bearer auth, and body parsing, ready to import
+- **`fileUpload()`**: Multer-style multipart uploads, with `MemoryStorage`, `DiskStorage`, or a custom storage engine
+- **Hooks**: observe the request lifecycle without writing middleware
+- **Adapters**: `@rasenganjs/runtime` ships Node, Bun, and Workerd adapters, plus bridges to mount Futon inside an existing **Express** app or deploy it to any **WinterCG**-compatible platform
 
 ### Quick start
 
 by using [create-rasengan CLI](/packages/create-rasengan) you can create a new Futon project with the following command:
 
 ```bash title="Terminal"
-npx create-rasengan@beta --king futon
+npx create-rasengan@beta --kind futon
 ```
 
 The generated project will contain the following code
@@ -89,17 +89,17 @@ runtime.serve(app, {
 
 ## Introducing Rasengan Server
 
-`@rasenganjs/server` is where Futon becomes a full backend framework. If you know Nest.js, the shape will feel familiar — **controllers**, **modules**, and a **dependency injection container** — but built on Futon's runtime-agnostic core, so the same server code runs on Node, Bun, or Workerd.
+`@rasenganjs/server` is where Futon becomes a full backend framework. If you know Nest.js, the shape will feel familiar with **controllers**, **modules**, and a **dependency injection container**, but built on Futon's runtime-agnostic core, so the same server code runs on Node, Bun, or Workerd.
 
 ### What's inside
 
-- **Controllers & modules** — group routes with `Controller`, wire everything together with `defineModule()`
-- **Dependency injection** — providers, tokens, lifecycle hooks (`onInit`/`onDestroy`), and module-scoped visibility (`imports`/`exports`/`global`)
-- **Schema validation** — attach a Zod schema to a route or controller and get validated, typed input automatically, powered by `@rasenganjs/validators`
-- **WebSockets** — low-level `app.websocket()` routes, or NestJS-style **Gateways** with rooms and broadcasting via [`@rasenganjs/ws`](/packages/ws)
-- **Background queues** — [`@rasenganjs/queue`](/packages/queue) for jobs, retries with backoff, and recurring schedules — the `Controller` equivalent for async work
-- **Database** — first-party [Drizzle ORM](/packages/drizzle) integration through `DrizzleModule.forRoot()`
-- **Module plugins** — an extension point that lets ecosystem packages (`ws`, `queue`, `drizzle`) add their own fields to `defineModule()`
+- **Controllers & modules**: group routes with `Controller`, wire everything together with `defineModule()`
+- **Dependency injection**: providers, tokens, lifecycle hooks (`onInit`/`onDestroy`), and module-scoped visibility (`imports`/`exports`/`global`)
+- **Schema validation**: attach a Zod schema to a route or controller and get validated, typed input automatically, powered by `@rasenganjs/validators`
+- **WebSockets**: low-level `app.websocket()` routes, or NestJS-style **Gateways** with rooms and broadcasting via [`@rasenganjs/ws`](/packages/ws)
+- **Background queues**: [`@rasenganjs/queue`](/packages/queue) for jobs, retries with backoff, and recurring schedules, the `Controller` equivalent for async work
+- **Database**: first-party [Drizzle ORM](/packages/drizzle) integration through `DrizzleModule.forRoot()`
+- **Module plugins**: an extension point that lets ecosystem packages (`ws`, `queue`, `drizzle`) add their own fields to `defineModule()`
 
 ### Quick start
 
@@ -137,9 +137,9 @@ npm run dev
 
 ## One ecosystem, every layer
 
-Futon and Rasengan Server join Rasengan as the three pillars of the ecosystem — you can see how they connect on the [homepage](/). Each one works standalone, but they share the same conventions on purpose: if you know one, you're not starting from zero on the others.
+Futon and Rasengan Server join Rasengan as the three pillars of the ecosystem. You can see how they connect on the [homepage](/). Each one works standalone, but they share the same conventions on purpose: if you know one, you're not starting from zero on the others.
 
-We've also published [agent skills](/skills) for both frameworks — `rasengan-futon-*` and `rasengan-server-*` — so AI coding assistants get the same level of support for the backend as they already do for the frontend.
+We've also published [agent skills](/skills) for both frameworks `rasengan-futon-*` and `rasengan-server-*`, so AI coding assistants get the same level of support for the backend as they already do for the frontend.
 
 ```bash title="Terminal"
 npx skills add rasengan-dev/agent-skills --all
@@ -149,7 +149,7 @@ npx skills add rasengan-dev/agent-skills --all
 
 ## Beta, honestly
 
-Both `@rasenganjs/futon` and `@rasenganjs/server` are shipping as **public betas** today. The core APIs — controllers, modules, DI, the router, middleware — are stable enough to build on, but expect some rough edges and breaking changes before v1. We'd rather ship early and shape these frameworks with real feedback than polish in isolation.
+Both `@rasenganjs/futon` and `@rasenganjs/server` are shipping as **public betas** today. The core APIs, including controllers, modules, DI, the router, and middleware are stable enough to build on, but expect some rough edges and breaking changes before v1. We'd rather ship early and shape these frameworks with real feedback than polish in isolation.
 
 ## What's next?
 

--- a/apps/docs-v2/src/app/_routes/blog/rasengan-i18n-stable-and-io.page.mdx
+++ b/apps/docs-v2/src/app/_routes/blog/rasengan-i18n-stable-and-io.page.mdx
@@ -144,7 +144,7 @@ Learn more in the [IO documentation](/packages/io).
 Both packages are available now on npm. We are actively working on:
 
 - **Query** (`@rasenganjs/query`) — Data fetching and cache management (coming soon)
-- **Sitemap** (`@rasenganjs/sitemap`) — Automatic sitemap generation (coming soon)
+- **Sitemap** (`@rasenganjs/sitemap`): [Automatic sitemap generation](/packages/sitemap), available now
 - **More adapters** — Netlify adapter, Cloudflare Workers support
 
 As always, feedback and contributions are welcome.

--- a/apps/docs-v2/src/components/common/layout/navbar.tsx
+++ b/apps/docs-v2/src/components/common/layout/navbar.tsx
@@ -1,6 +1,13 @@
-import { Link } from 'rasengan';
+import { Link, useLocation } from 'rasengan';
 import ThemeButton from '../atoms/buttons/theme-button';
-import { ArrowUpRight, ChevronDown, Coffee } from 'lucide-react';
+import {
+  ArrowUpRight,
+  ChevronDown,
+  Coffee,
+  Menu,
+  PanelLeft,
+  X,
+} from 'lucide-react';
 import { ComponentProps } from 'react';
 import { twMerge } from 'tailwind-merge';
 import AppLogo from '../atoms/logo';
@@ -13,8 +20,19 @@ import {
 } from '@/components/ui/popover';
 import { useTheme } from '@rasenganjs/theme';
 import Search from '@/components/ui/search';
+import { useMobileMenuStore } from '@/store/mobile-menu';
+import { useNavigationStore } from '@/store/navigation';
+import { AnimatePresence, motion } from 'motion/react';
 
 const env = import.meta.env;
+
+const productLinks = [
+  { name: 'Rasengan UI', href: 'https://ui.rasengan.dev' },
+  { name: 'Rasengan Hub', href: 'https://hub.rasengan.dev' },
+  { name: 'Chidori', href: 'https://chidori.rasengan.dev' },
+  { name: 'Nindo', href: 'https://nindo.rasengan.dev' },
+  { name: 'Chunin', href: 'https://chunin.rasengan.dev' },
+];
 
 type Props = {
   className?: ComponentProps<'header'>['className'];
@@ -22,6 +40,7 @@ type Props = {
 
 export default function Navbar({ className }: Props) {
   const { isDark } = useTheme();
+  const { pathname } = useLocation();
 
   const algoliaAppId = env.RASENGAN_ALGOLIA_APP_ID;
   const algoliaApiKey = env.RASENGAN_ALGOLIA_API_KEY;
@@ -32,6 +51,18 @@ export default function Navbar({ className }: Props) {
     algoliaAppId && algoliaApiKey && algoliaIndexName
   );
 
+  // Two independent mobile controllers: the main site menu (this
+  // component, every page) and the docs sidebar (only relevant on
+  // /docs and /packages, driven by the store sidebar.tsx already reads).
+  const {
+    isOpen: isMenuOpen,
+    toggle: toggleMenu,
+    close: closeMenu,
+  } = useMobileMenuStore();
+  const { isOpen: isSidebarOpen, toggle: toggleSidebar } = useNavigationStore();
+  const hasSidebar =
+    pathname.startsWith('/docs') || pathname.startsWith('/packages');
+
   return (
     <header
       id="navbar"
@@ -41,7 +72,22 @@ export default function Navbar({ className }: Props) {
       )}
     >
       <div className="flex items-center gap-8">
-        <AppLogo size="sm" />
+        <div className="flex items-center gap-1">
+          {hasSidebar && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="lg:hidden"
+              aria-label={isSidebarOpen ? 'Close sidebar' : 'Open sidebar'}
+              onClick={toggleSidebar}
+            >
+              <PanelLeft size={20} />
+            </Button>
+          )}
+
+          <AppLogo size="sm" />
+        </div>
 
         <nav className="hidden lg:block">
           <ul className="flex items-center gap-1 text-foreground text-sm">
@@ -64,56 +110,19 @@ export default function Navbar({ className }: Props) {
               <PopoverContent className={isDark ? 'dark bg-input/30' : ''}>
                 <nav className="text-sm">
                   <ul className="flex flex-col gap-2">
-                    <Link
-                      to="https://ui.rasengan.dev"
-                      className="hover:text-primary"
-                      target="_blank"
-                    >
-                      <li className="flex items-center gap-2">
-                        <span>Rasengan UI</span>
-                        <ArrowUpRight size={16} />
-                      </li>
-                    </Link>
-                    <Link
-                      to="https://hub.rasengan.dev"
-                      className="hover:text-primary"
-                      target="_blank"
-                    >
-                      <li className="flex items-center gap-2">
-                        <span>Rasengan Hub</span>
-                        <ArrowUpRight size={16} />
-                      </li>
-                    </Link>
-                    <Link
-                      to="https://chidori.rasengan.dev"
-                      className="hover:text-primary"
-                      target="_blank"
-                    >
-                      <li className="flex items-center gap-2">
-                        <span>Chidori</span>
-                        <ArrowUpRight size={16} />
-                      </li>
-                    </Link>
-                    <Link
-                      to="https://nindo.rasengan.dev"
-                      className="hover:text-primary"
-                      target="_blank"
-                    >
-                      <li className="flex items-center gap-2">
-                        <span>Nindo</span>
-                        <ArrowUpRight size={16} />
-                      </li>
-                    </Link>
-                    <Link
-                      to="https://chunin.rasengan.dev"
-                      className="hover:text-primary"
-                      target="_blank"
-                    >
-                      <li className="flex items-center gap-2">
-                        <span>Chunin</span>
-                        <ArrowUpRight size={16} />
-                      </li>
-                    </Link>
+                    {productLinks.map((product) => (
+                      <Link
+                        key={product.name}
+                        to={product.href}
+                        className="hover:text-primary"
+                        target="_blank"
+                      >
+                        <li className="flex items-center gap-2">
+                          <span>{product.name}</span>
+                          <ArrowUpRight size={16} />
+                        </li>
+                      </Link>
+                    ))}
                   </ul>
                 </nav>
               </PopoverContent>
@@ -186,7 +195,74 @@ export default function Navbar({ className }: Props) {
             <span>Support us</span>
           </Button>
         </Link>
+
+        {/* vertical separator */}
+        <div className="h-4 w-[1px] bg-border dark:bg-input lg:hidden"></div>
+
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="lg:hidden"
+          aria-label={isMenuOpen ? 'Close menu' : 'Open menu'}
+          onClick={toggleMenu}
+        >
+          {isMenuOpen ? <X size={20} /> : <Menu size={20} />}
+        </Button>
       </div>
+
+      <AnimatePresence>
+        {isMenuOpen && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={closeMenu}
+            className="z-20 fixed top-0 left-0 w-full h-full bg-background/90 lg:hidden"
+          />
+        )}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {isMenuOpen && (
+          <motion.div
+            key="mobile-menu"
+            initial={{ x: '100%' }}
+            animate={{ x: 0 }}
+            exit={{ x: '100%' }}
+            transition={{ duration: 0.2 }}
+            className="z-40 fixed top-0 right-0 h-full w-[280px] bg-background border-l border-border/40 dark:border-border lg:hidden"
+          >
+            <nav className="flex flex-col gap-1 p-6 pt-20 text-sm">
+              {NavigationData.navbar.map((nav) => (
+                <Link key={nav.id} to={nav.link ?? '#'} onClick={closeMenu}>
+                  <div className="hover:bg-muted dark:hover:bg-muted transition-all px-3 py-2 rounded-md font-semibold">
+                    {nav.name}
+                  </div>
+                </Link>
+              ))}
+
+              <div className="mt-4 px-3 text-[12px] font-mono text-foreground/60">
+                Products
+              </div>
+              {productLinks.map((product) => (
+                <Link
+                  key={product.name}
+                  to={product.href}
+                  target="_blank"
+                  onClick={closeMenu}
+                >
+                  <div className="hover:bg-muted dark:hover:bg-muted transition-all px-3 py-2 rounded-md flex items-center gap-2">
+                    <span>{product.name}</span>
+                    <ArrowUpRight size={16} />
+                  </div>
+                </Link>
+              ))}
+            </nav>
+          </motion.div>
+        )}
+      </AnimatePresence>
     </header>
   );
 }

--- a/apps/docs-v2/src/components/home/showcase.tsx
+++ b/apps/docs-v2/src/components/home/showcase.tsx
@@ -3,10 +3,14 @@ import { AnimatePresence, motion } from 'motion/react';
 import {
   Check,
   ChevronRight,
+  ChevronsUpDown,
   Copy,
   FileCode2,
   Folder,
   FolderOpen,
+  Layers,
+  Maximize2,
+  Minus,
   TerminalSquare,
   X,
 } from 'lucide-react';
@@ -170,12 +174,28 @@ function FileTreeNode({
 
 // ── Window chrome ────────────────────────────────────────────
 
-function TrafficLights() {
+function TrafficLights({
+  onMaximize,
+  onMinimize,
+}: {
+  onMaximize: () => void;
+  onMinimize: () => void;
+}) {
   return (
     <div aria-hidden="true" className="flex items-center gap-2">
-      <span className="size-3 rounded-full bg-[#FF5F57]" />
-      <span className="size-3 rounded-full bg-[#FEBC2E]" />
-      <span className="size-3 rounded-full bg-[#28C840]" />
+      <span className="size-4 rounded-full bg-[#FF5F57]" />
+      <span
+        className="size-4 rounded-full bg-[#FEBC2E] flex items-center justify-center [&>svg]:text-transparent hover:[&>svg]:text-black transition-all"
+        onClick={onMinimize}
+      >
+        <Minus size={10} />
+      </span>
+      <span
+        className="size-4 rounded-full bg-[#28C840] flex items-center justify-center [&>svg]:text-transparent hover:[&>svg]:text-black transition-all"
+        onClick={onMaximize}
+      >
+        <ChevronsUpDown size={10} className="rotate-[45deg]" />
+      </span>
     </div>
   );
 }
@@ -447,6 +467,8 @@ export default function CodeEditor({
     return initial;
   });
 
+  const [isMaximized, setIsMaximized] = useState(false);
+
   const activeFramework =
     frameworks.find((f) => f.key === activeFrameworkKey) ?? frameworks[0];
 
@@ -515,12 +537,20 @@ export default function CodeEditor({
   const [mobileTerminalOpen, setMobileTerminalOpen] = useState(false);
 
   return (
-    <div className="w-full overflow-hidden rounded-xl border border-border bg-(--code-block-bg)">
+    <div
+      className={cn(
+        'w-full overflow-hidden rounded-xl border border-border bg-(--code-block-bg)',
+        isMaximized && 'fixed inset-0 z-50 rounded-none'
+      )}
+    >
       {/* ── Desktop / tablet ── */}
       <div className="hidden md:block">
         <div className="w-full flex items-center justify-between bg-muted  border-b border-border px-4 pr-1">
           <div className="flex h-10 items-center gap-3">
-            <TrafficLights />
+            <TrafficLights
+              onMaximize={() => setIsMaximized(true)}
+              onMinimize={() => setIsMaximized(false)}
+            />
             <span className="truncate font-mono text-xs text-foreground/50">
               {activeFile ?? activeFramework.title}
             </span>
@@ -536,7 +566,7 @@ export default function CodeEditor({
         <ResizablePanelGroup
           id="home-code-editor-vertical"
           direction="vertical"
-          className="h-[660px]!"
+          className={cn(isMaximized ? 'h-screen!' : 'h-[660px]!')}
         >
           <ResizablePanel
             id="home-code-editor-main"
@@ -605,7 +635,10 @@ export default function CodeEditor({
       {/* ── Mobile ── */}
       <div className="md:hidden">
         <div className="flex h-10 items-center justify-between border-b border-border bg-muted px-3">
-          <TrafficLights />
+          <TrafficLights
+            onMaximize={() => setIsMaximized(true)}
+            onMinimize={() => setIsMaximized(false)}
+          />
 
           <div className="flex items-center gap-1">
             <button

--- a/apps/docs-v2/src/data/docs/sections/documentation.tsx
+++ b/apps/docs-v2/src/data/docs/sections/documentation.tsx
@@ -84,7 +84,6 @@ export const documentationNavigation: NavigationItem[] = [
             name: 'File-Based Routing',
             link: '/docs/routing/file-based-routing',
             level: 3,
-            isNew: true,
           },
           {
             id: randomId(),
@@ -110,7 +109,6 @@ export const documentationNavigation: NavigationItem[] = [
             name: 'Active Links',
             link: '/docs/routing/active-link',
             level: 3,
-            isNew: true,
           },
           {
             id: randomId(),
@@ -205,7 +203,6 @@ export const documentationNavigation: NavigationItem[] = [
             name: 'React Compiler',
             link: '/docs/optimizing/react-compiler',
             level: 3,
-            isNew: true,
           },
         ],
       },
@@ -284,7 +281,6 @@ export const documentationNavigation: NavigationItem[] = [
             name: 'NavLink',
             link: '/docs/api-reference/components/navlink',
             level: 3,
-            isNew: true,
           },
           {
             id: randomId(),
@@ -327,7 +323,6 @@ export const documentationNavigation: NavigationItem[] = [
             name: 'ScrollRestoration',
             link: '/docs/api-reference/components/scroll-restoration',
             level: 3,
-            isNew: true,
           },
         ],
       },

--- a/apps/docs-v2/src/data/docs/sections/packages.tsx
+++ b/apps/docs-v2/src/data/docs/sections/packages.tsx
@@ -33,7 +33,6 @@ export const packagesNavigation: NavigationItem[] = [
         link: '/packages/kurama',
         level: 2,
         // visible: false,
-        isNew: true,
       },
       {
         id: randomId(),
@@ -49,15 +48,13 @@ export const packagesNavigation: NavigationItem[] = [
         link: '/packages/kage-demo',
         level: 2,
         // visible: false,
-        isNew: true,
       },
       {
         id: randomId(),
         name: 'Sitemap',
-        link: '#',
+        link: '/packages/sitemap',
         level: 2,
-        // visible: false,
-        isComingSoon: true,
+        isNew: true,
       },
       {
         id: randomId(),

--- a/apps/docs-v2/src/store/mobile-menu/index.ts
+++ b/apps/docs-v2/src/store/mobile-menu/index.ts
@@ -1,8 +1,9 @@
 import { create } from 'zustand';
 
 /**
- * Controls the docs sidebar drawer on mobile (< lg). Desktop shows the
- * sidebar inline and never touches this store.
+ * Controls the main site nav drawer on mobile (< lg): Docs/Skills/Blog/
+ * Showcase/Products. Separate from the docs sidebar's own store
+ * (@/store/navigation) — the two can be open independently on doc pages.
  */
 type State = {
   isOpen: boolean;
@@ -14,7 +15,7 @@ type Actions = {
   toggle: () => void;
 };
 
-export const useNavigationStore = create<State & Actions>((set) => ({
+export const useMobileMenuStore = create<State & Actions>((set) => ({
   isOpen: false,
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),

--- a/packages/ecosystem/sitemap/CHANGELOG.md
+++ b/packages/ecosystem/sitemap/CHANGELOG.md
@@ -1,0 +1,5 @@
+## Unreleased
+
+### Features
+
+- initial release: `defineSitemapConfig()` + `rasengan-sitemap` CLI, generates `sitemap.xml` after `rasengan build` completes for `prerender` mode (RFC-0011 Phase 1)

--- a/packages/ecosystem/sitemap/README.md
+++ b/packages/ecosystem/sitemap/README.md
@@ -1,0 +1,78 @@
+# Rasengan Sitemap
+
+[![npm version](https://badge.fury.io/js/@rasenganjs%2Fsitemap.svg)](https://badge.fury.io/js/@rasenganjs%2Fsitemap)
+![NPM Downloads](https://img.shields.io/npm/dm/%40rasenganjs%2Fsitemap)
+[![GitHub license](https://img.shields.io/github/license/rasengan-dev/rasenganjs)](https://github.com/rasengan-dev/rasenganjs/blob/main/LICENSE)
+
+Automatic `sitemap.xml` generation for [Rasengan.js](https://rasengan.dev) frontend apps, in `ssr` or `prerender` (SSG) mode.
+
+`rasengan-sitemap` runs as a separate CLI step after `rasengan build`, not as a Vite plugin, so it always reads the final, complete build output.
+
+## Installation
+
+```bash
+npm install -D @rasenganjs/sitemap
+```
+
+## Usage
+
+Create a `rasengan-sitemap.config.js` at your project root:
+
+```ts
+import { defineSitemapConfig } from '@rasenganjs/sitemap';
+
+export default defineSitemapConfig({
+  siteUrl: 'https://your-site.com', // required
+  changefreq: 'weekly', // optional
+  priority: 0.7, // optional
+  exclude: ['/admin/*'], // optional, glob against the route path
+  generateRobotsTxt: false, // optional, off by default
+});
+```
+
+Then run the CLI after your build:
+
+```bash
+rasengan build && rasengan-sitemap
+```
+
+Or wire it into `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "rasengan build && rasengan-sitemap"
+  }
+}
+```
+
+`rasengan-sitemap` writes `sitemap.xml` into the same directory the app actually produced: `static/` for `prerender: true`, `dist/client/` for `ssr: true`.
+
+Pure SPA builds (`ssr: false, prerender: false`) aren't supported: no server-rendered route bundle is produced to enumerate routes from. Temporarily set `ssr: true`, run `rasengan build`, then `rasengan-sitemap`, the route tree is identical either way.
+
+## What Gets Excluded Automatically
+
+- The catch-all `*`/404 route.
+- `_api/` routes (excluded by construction, never part of the page route tree).
+- Any route matching a redirect `source` in `rasengan.config.js`'s `redirects()`.
+- Anything matching your own `exclude` glob patterns.
+
+## Full Documentation
+
+See the [Rasengan Sitemap docs](https://rasengan.dev/packages/sitemap) for the full API, including `transform` for per-route overrides.
+
+## Community
+
+The Rasengan.js community can be found on [GitHub Discussions](https://github.com/rasengan-dev/rasenganjs/discussions) where you can ask questions, voice ideas, and share your projects with other people.
+
+We also have a [Twitter](https://twitter.com/rasenganjs) account where you can follow us to get the latest news about Rasengan.js.
+
+## License
+
+Rasengan.js is [MIT licensed](https://github.com/rasengan-dev/rasenganjs/blob/main/LICENSE).
+
+## Authors
+
+Here is the authors list:
+
+- Dilane Kombou ([**@dilanekombou**](https://twitter.com/dilanekombou))

--- a/packages/ecosystem/sitemap/bin.js
+++ b/packages/ecosystem/sitemap/bin.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import process from 'process';
+
+import('./dist/cli.js').catch((err) => {
+  console.error('Failed to start rasengan-sitemap:', err);
+  process.exit(1);
+});

--- a/packages/ecosystem/sitemap/dist/cli.cjs
+++ b/packages/ecosystem/sitemap/dist/cli.cjs
@@ -1,0 +1,217 @@
+"use strict";
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/cli.ts
+var cli_exports = {};
+__export(cli_exports, {
+  main: () => main
+});
+module.exports = __toCommonJS(cli_exports);
+var import_promises2 = require("fs/promises");
+var import_node_path5 = __toESM(require("path"), 1);
+var import_node_process = __toESM(require("process"), 1);
+
+// src/config-loader.ts
+var import_node_path = __toESM(require("path"), 1);
+var import_node_url = require("url");
+async function loadSitemapConfig(cwd) {
+  const configPath = import_node_path.default.posix.join(cwd, "rasengan-sitemap.config.js");
+  let mod;
+  try {
+    mod = await import((0, import_node_url.pathToFileURL)(configPath).href);
+  } catch (err) {
+    throw new Error(
+      `Could not load rasengan-sitemap.config.js at ${configPath}. Create one exporting defineSitemapConfig({ siteUrl: '...' }).
+${err.message}`
+    );
+  }
+  const config = mod.default ?? mod;
+  if (!config?.siteUrl) {
+    throw new Error(
+      "`siteUrl` is required in rasengan-sitemap.config.js, e.g. defineSitemapConfig({ siteUrl: 'https://example.com' })."
+    );
+  }
+  return config;
+}
+
+// src/build-config.ts
+var import_promises = require("fs/promises");
+var import_node_path2 = __toESM(require("path"), 1);
+async function loadBuildConfig(cwd) {
+  const candidates = [
+    import_node_path2.default.posix.join(cwd, "dist", "client", "assets", "config.json"),
+    import_node_path2.default.posix.join(cwd, "dist", "assets", "config.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      await (0, import_promises.access)(candidate);
+      const text = await (0, import_promises.readFile)(candidate, "utf-8");
+      const parsed = JSON.parse(text);
+      return { ...parsed, redirects: parsed.redirects ?? [] };
+    } catch {
+    }
+  }
+  throw new Error(
+    "Could not find dist/client/assets/config.json or dist/assets/config.json. Run `rasengan build` before `rasengan-sitemap`."
+  );
+}
+
+// src/collect-routes.ts
+var import_node_path3 = __toESM(require("path"), 1);
+var import_node_url2 = require("url");
+var import_rasengan = require("rasengan");
+async function collectRoutePaths(cwd, build) {
+  const serverPathDirectory = build.prerender ? "prerender" : build.buildOptions.serverPathDirectory;
+  const appRouterPath = import_node_path3.default.posix.join(
+    cwd,
+    build.buildOptions.buildDirectory,
+    serverPathDirectory,
+    "app.router.js"
+  );
+  let AppRouter;
+  try {
+    const mod = await import((0, import_node_url2.pathToFileURL)(appRouterPath).href);
+    AppRouter = await (mod.default ?? mod);
+  } catch (err) {
+    throw new Error(
+      `Could not import the built router at ${appRouterPath}. Make sure \`rasengan build\` completed successfully.
+${err.message}`
+    );
+  }
+  const routeTree = (0, import_rasengan.generateRoutes)(AppRouter);
+  const { paths, error } = await (0, import_rasengan.getAllRoutesPath)(routeTree);
+  const filtered = paths.filter((p) => !p.includes("*"));
+  return { paths: filtered, warnings: Array.from(error) };
+}
+
+// src/output-dir.ts
+var import_node_path4 = __toESM(require("path"), 1);
+function resolveOutputDirectory(cwd, build) {
+  if (build.prerender) {
+    return import_node_path4.default.posix.join(cwd, build.buildOptions.staticDirectory);
+  }
+  if (build.ssr) {
+    return import_node_path4.default.posix.join(
+      cwd,
+      build.buildOptions.buildDirectory,
+      build.buildOptions.clientPathDirectory
+    );
+  }
+  return import_node_path4.default.posix.join(cwd, build.buildOptions.buildDirectory);
+}
+
+// src/generate-xml.ts
+function matchGlob(pattern, value) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  return regex.test(value);
+}
+function escapeXml(value) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+function renderUrl(entry, siteUrl) {
+  const loc = new URL(entry.loc, siteUrl).toString();
+  const lines = [`    <loc>${escapeXml(loc)}</loc>`];
+  if (entry.changefreq) {
+    lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+  }
+  if (entry.priority !== void 0) {
+    lines.push(`    <priority>${entry.priority}</priority>`);
+  }
+  return `  <url>
+${lines.join("\n")}
+  </url>`;
+}
+async function buildSitemapXml(routePaths, redirectSources, config) {
+  const exclude = config.exclude ?? [];
+  const entries = [];
+  for (const routePath of routePaths) {
+    if (redirectSources.has(routePath)) continue;
+    if (exclude.some((pattern) => matchGlob(pattern, routePath))) continue;
+    const entry = config.transform ? await config.transform(routePath) : {
+      loc: routePath,
+      changefreq: config.changefreq,
+      priority: config.priority
+    };
+    entries.push(entry);
+  }
+  const urls = entries.map((entry) => renderUrl(entry, config.siteUrl)).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+// src/cli.ts
+var LOG_PREFIX = "[rasengan-sitemap]";
+function buildRobotsTxt(siteUrl) {
+  const sitemapUrl = new URL("sitemap.xml", siteUrl).toString();
+  return `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapUrl}
+`;
+}
+async function main() {
+  const cwd = import_node_process.default.cwd();
+  try {
+    const config = await loadSitemapConfig(cwd);
+    const build = await loadBuildConfig(cwd);
+    if (!build.prerender) {
+      throw new Error(
+        "rasengan-sitemap currently only supports SSG (prerender: true) apps. SSR/SPA support is planned for a future release."
+      );
+    }
+    const { paths, warnings } = await collectRoutePaths(cwd, build);
+    for (const warning of warnings) {
+      console.warn(`${LOG_PREFIX} warning: ${warning}`);
+    }
+    const redirectSources = new Set(build.redirects.map((redirect) => redirect.source));
+    const xml = await buildSitemapXml(paths, redirectSources, config);
+    const outputDir = resolveOutputDirectory(cwd, build);
+    await (0, import_promises2.mkdir)(outputDir, { recursive: true });
+    const sitemapPath = import_node_path5.default.posix.join(outputDir, "sitemap.xml");
+    await (0, import_promises2.writeFile)(sitemapPath, xml, "utf-8");
+    console.log(`${LOG_PREFIX} Wrote ${paths.length} URLs to ${sitemapPath}`);
+    if (config.generateRobotsTxt) {
+      const robotsPath = import_node_path5.default.posix.join(outputDir, "robots.txt");
+      await (0, import_promises2.writeFile)(robotsPath, buildRobotsTxt(config.siteUrl), "utf-8");
+      console.log(`${LOG_PREFIX} Wrote ${robotsPath}`);
+    }
+  } catch (err) {
+    console.error(`${LOG_PREFIX} ${err.message}`);
+    import_node_process.default.exit(1);
+  }
+}
+main();
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  main
+});

--- a/packages/ecosystem/sitemap/dist/cli.cjs
+++ b/packages/ecosystem/sitemap/dist/cli.cjs
@@ -184,16 +184,18 @@ async function main() {
   try {
     const config = await loadSitemapConfig(cwd);
     const build = await loadBuildConfig(cwd);
-    if (!build.prerender) {
+    if (!build.prerender && !build.ssr) {
       throw new Error(
-        "rasengan-sitemap currently only supports SSG (prerender: true) apps. SSR/SPA support is planned for a future release."
+        "rasengan-sitemap needs a server-rendered route bundle to enumerate routes, which pure SPA builds (ssr: false, prerender: false) do not produce. Temporarily set `ssr: true` in rasengan.config.js, run `rasengan build`, then `rasengan-sitemap` (the route tree is the same regardless of ssr/spa, only the rendering strategy differs)."
       );
     }
     const { paths, warnings } = await collectRoutePaths(cwd, build);
     for (const warning of warnings) {
       console.warn(`${LOG_PREFIX} warning: ${warning}`);
     }
-    const redirectSources = new Set(build.redirects.map((redirect) => redirect.source));
+    const redirectSources = new Set(
+      build.redirects.map((redirect) => redirect.source)
+    );
     const xml = await buildSitemapXml(paths, redirectSources, config);
     const outputDir = resolveOutputDirectory(cwd, build);
     await (0, import_promises2.mkdir)(outputDir, { recursive: true });

--- a/packages/ecosystem/sitemap/dist/cli.js
+++ b/packages/ecosystem/sitemap/dist/cli.js
@@ -150,16 +150,18 @@ async function main() {
   try {
     const config = await loadSitemapConfig(cwd);
     const build = await loadBuildConfig(cwd);
-    if (!build.prerender) {
+    if (!build.prerender && !build.ssr) {
       throw new Error(
-        "rasengan-sitemap currently only supports SSG (prerender: true) apps. SSR/SPA support is planned for a future release."
+        "rasengan-sitemap needs a server-rendered route bundle to enumerate routes, which pure SPA builds (ssr: false, prerender: false) do not produce. Temporarily set `ssr: true` in rasengan.config.js, run `rasengan build`, then `rasengan-sitemap` (the route tree is the same regardless of ssr/spa, only the rendering strategy differs)."
       );
     }
     const { paths, warnings } = await collectRoutePaths(cwd, build);
     for (const warning of warnings) {
       console.warn(`${LOG_PREFIX} warning: ${warning}`);
     }
-    const redirectSources = new Set(build.redirects.map((redirect) => redirect.source));
+    const redirectSources = new Set(
+      build.redirects.map((redirect) => redirect.source)
+    );
     const xml = await buildSitemapXml(paths, redirectSources, config);
     const outputDir = resolveOutputDirectory(cwd, build);
     await mkdir(outputDir, { recursive: true });

--- a/packages/ecosystem/sitemap/dist/cli.js
+++ b/packages/ecosystem/sitemap/dist/cli.js
@@ -1,0 +1,182 @@
+// src/cli.ts
+import { mkdir, writeFile } from "fs/promises";
+import path5 from "path";
+import process from "process";
+
+// src/config-loader.ts
+import path from "path";
+import { pathToFileURL } from "url";
+async function loadSitemapConfig(cwd) {
+  const configPath = path.posix.join(cwd, "rasengan-sitemap.config.js");
+  let mod;
+  try {
+    mod = await import(pathToFileURL(configPath).href);
+  } catch (err) {
+    throw new Error(
+      `Could not load rasengan-sitemap.config.js at ${configPath}. Create one exporting defineSitemapConfig({ siteUrl: '...' }).
+${err.message}`
+    );
+  }
+  const config = mod.default ?? mod;
+  if (!config?.siteUrl) {
+    throw new Error(
+      "`siteUrl` is required in rasengan-sitemap.config.js, e.g. defineSitemapConfig({ siteUrl: 'https://example.com' })."
+    );
+  }
+  return config;
+}
+
+// src/build-config.ts
+import { access, readFile } from "fs/promises";
+import path2 from "path";
+async function loadBuildConfig(cwd) {
+  const candidates = [
+    path2.posix.join(cwd, "dist", "client", "assets", "config.json"),
+    path2.posix.join(cwd, "dist", "assets", "config.json")
+  ];
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      const text = await readFile(candidate, "utf-8");
+      const parsed = JSON.parse(text);
+      return { ...parsed, redirects: parsed.redirects ?? [] };
+    } catch {
+    }
+  }
+  throw new Error(
+    "Could not find dist/client/assets/config.json or dist/assets/config.json. Run `rasengan build` before `rasengan-sitemap`."
+  );
+}
+
+// src/collect-routes.ts
+import path3 from "path";
+import { pathToFileURL as pathToFileURL2 } from "url";
+import { generateRoutes, getAllRoutesPath } from "rasengan";
+async function collectRoutePaths(cwd, build) {
+  const serverPathDirectory = build.prerender ? "prerender" : build.buildOptions.serverPathDirectory;
+  const appRouterPath = path3.posix.join(
+    cwd,
+    build.buildOptions.buildDirectory,
+    serverPathDirectory,
+    "app.router.js"
+  );
+  let AppRouter;
+  try {
+    const mod = await import(pathToFileURL2(appRouterPath).href);
+    AppRouter = await (mod.default ?? mod);
+  } catch (err) {
+    throw new Error(
+      `Could not import the built router at ${appRouterPath}. Make sure \`rasengan build\` completed successfully.
+${err.message}`
+    );
+  }
+  const routeTree = generateRoutes(AppRouter);
+  const { paths, error } = await getAllRoutesPath(routeTree);
+  const filtered = paths.filter((p) => !p.includes("*"));
+  return { paths: filtered, warnings: Array.from(error) };
+}
+
+// src/output-dir.ts
+import path4 from "path";
+function resolveOutputDirectory(cwd, build) {
+  if (build.prerender) {
+    return path4.posix.join(cwd, build.buildOptions.staticDirectory);
+  }
+  if (build.ssr) {
+    return path4.posix.join(
+      cwd,
+      build.buildOptions.buildDirectory,
+      build.buildOptions.clientPathDirectory
+    );
+  }
+  return path4.posix.join(cwd, build.buildOptions.buildDirectory);
+}
+
+// src/generate-xml.ts
+function matchGlob(pattern, value) {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`^${escaped.replace(/\*/g, ".*")}$`);
+  return regex.test(value);
+}
+function escapeXml(value) {
+  return value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&apos;");
+}
+function renderUrl(entry, siteUrl) {
+  const loc = new URL(entry.loc, siteUrl).toString();
+  const lines = [`    <loc>${escapeXml(loc)}</loc>`];
+  if (entry.changefreq) {
+    lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+  }
+  if (entry.priority !== void 0) {
+    lines.push(`    <priority>${entry.priority}</priority>`);
+  }
+  return `  <url>
+${lines.join("\n")}
+  </url>`;
+}
+async function buildSitemapXml(routePaths, redirectSources, config) {
+  const exclude = config.exclude ?? [];
+  const entries = [];
+  for (const routePath of routePaths) {
+    if (redirectSources.has(routePath)) continue;
+    if (exclude.some((pattern) => matchGlob(pattern, routePath))) continue;
+    const entry = config.transform ? await config.transform(routePath) : {
+      loc: routePath,
+      changefreq: config.changefreq,
+      priority: config.priority
+    };
+    entries.push(entry);
+  }
+  const urls = entries.map((entry) => renderUrl(entry, config.siteUrl)).join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>
+`;
+}
+
+// src/cli.ts
+var LOG_PREFIX = "[rasengan-sitemap]";
+function buildRobotsTxt(siteUrl) {
+  const sitemapUrl = new URL("sitemap.xml", siteUrl).toString();
+  return `User-agent: *
+Allow: /
+
+Sitemap: ${sitemapUrl}
+`;
+}
+async function main() {
+  const cwd = process.cwd();
+  try {
+    const config = await loadSitemapConfig(cwd);
+    const build = await loadBuildConfig(cwd);
+    if (!build.prerender) {
+      throw new Error(
+        "rasengan-sitemap currently only supports SSG (prerender: true) apps. SSR/SPA support is planned for a future release."
+      );
+    }
+    const { paths, warnings } = await collectRoutePaths(cwd, build);
+    for (const warning of warnings) {
+      console.warn(`${LOG_PREFIX} warning: ${warning}`);
+    }
+    const redirectSources = new Set(build.redirects.map((redirect) => redirect.source));
+    const xml = await buildSitemapXml(paths, redirectSources, config);
+    const outputDir = resolveOutputDirectory(cwd, build);
+    await mkdir(outputDir, { recursive: true });
+    const sitemapPath = path5.posix.join(outputDir, "sitemap.xml");
+    await writeFile(sitemapPath, xml, "utf-8");
+    console.log(`${LOG_PREFIX} Wrote ${paths.length} URLs to ${sitemapPath}`);
+    if (config.generateRobotsTxt) {
+      const robotsPath = path5.posix.join(outputDir, "robots.txt");
+      await writeFile(robotsPath, buildRobotsTxt(config.siteUrl), "utf-8");
+      console.log(`${LOG_PREFIX} Wrote ${robotsPath}`);
+    }
+  } catch (err) {
+    console.error(`${LOG_PREFIX} ${err.message}`);
+    process.exit(1);
+  }
+}
+main();
+export {
+  main
+};

--- a/packages/ecosystem/sitemap/dist/index.cjs
+++ b/packages/ecosystem/sitemap/dist/index.cjs
@@ -1,0 +1,34 @@
+"use strict";
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// src/index.ts
+var src_exports = {};
+__export(src_exports, {
+  defineSitemapConfig: () => defineSitemapConfig
+});
+module.exports = __toCommonJS(src_exports);
+
+// src/define-config.ts
+function defineSitemapConfig(config) {
+  return config;
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  defineSitemapConfig
+});

--- a/packages/ecosystem/sitemap/dist/index.d.cts
+++ b/packages/ecosystem/sitemap/dist/index.d.cts
@@ -1,0 +1,39 @@
+type ChangeFrequency = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+interface SitemapEntry {
+    /** Route path (e.g. `/blog/hello`) or a full absolute URL. */
+    loc: string;
+    changefreq?: ChangeFrequency;
+    /** 0.0 to 1.0. */
+    priority?: number;
+}
+interface SitemapConfig {
+    /**
+     * Absolute base URL of the deployed site, e.g. `https://rasengan.dev`.
+     * Required: nothing in the framework itself has a concept of a
+     * site-wide base URL to fall back on.
+     */
+    siteUrl: string;
+    /** Glob patterns matched against each route path, e.g. `/admin/*`. */
+    exclude?: string[];
+    /** Static default applied to every route unless `transform` overrides it. */
+    changefreq?: ChangeFrequency;
+    /** Static default applied to every route unless `transform` overrides it. */
+    priority?: number;
+    /** Per-route override, called once per route path that survives `exclude`. */
+    transform?: (path: string) => SitemapEntry | Promise<SitemapEntry>;
+    /**
+     * Append a `Sitemap:` line to an existing `robots.txt`, or write a
+     * minimal one if none exists. Off by default so an existing
+     * hand-written robots.txt is never silently touched.
+     */
+    generateRobotsTxt?: boolean;
+}
+
+/**
+ * Typed pass-through helper for `rasengan-sitemap.config.js`. Returns the
+ * same object you pass in, with type-checking, same shape as `rasengan`'s
+ * own `defineConfig()`.
+ */
+declare function defineSitemapConfig(config: SitemapConfig): SitemapConfig;
+
+export { type ChangeFrequency, type SitemapConfig, type SitemapEntry, defineSitemapConfig };

--- a/packages/ecosystem/sitemap/dist/index.d.ts
+++ b/packages/ecosystem/sitemap/dist/index.d.ts
@@ -1,0 +1,39 @@
+type ChangeFrequency = 'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+interface SitemapEntry {
+    /** Route path (e.g. `/blog/hello`) or a full absolute URL. */
+    loc: string;
+    changefreq?: ChangeFrequency;
+    /** 0.0 to 1.0. */
+    priority?: number;
+}
+interface SitemapConfig {
+    /**
+     * Absolute base URL of the deployed site, e.g. `https://rasengan.dev`.
+     * Required: nothing in the framework itself has a concept of a
+     * site-wide base URL to fall back on.
+     */
+    siteUrl: string;
+    /** Glob patterns matched against each route path, e.g. `/admin/*`. */
+    exclude?: string[];
+    /** Static default applied to every route unless `transform` overrides it. */
+    changefreq?: ChangeFrequency;
+    /** Static default applied to every route unless `transform` overrides it. */
+    priority?: number;
+    /** Per-route override, called once per route path that survives `exclude`. */
+    transform?: (path: string) => SitemapEntry | Promise<SitemapEntry>;
+    /**
+     * Append a `Sitemap:` line to an existing `robots.txt`, or write a
+     * minimal one if none exists. Off by default so an existing
+     * hand-written robots.txt is never silently touched.
+     */
+    generateRobotsTxt?: boolean;
+}
+
+/**
+ * Typed pass-through helper for `rasengan-sitemap.config.js`. Returns the
+ * same object you pass in, with type-checking, same shape as `rasengan`'s
+ * own `defineConfig()`.
+ */
+declare function defineSitemapConfig(config: SitemapConfig): SitemapConfig;
+
+export { type ChangeFrequency, type SitemapConfig, type SitemapEntry, defineSitemapConfig };

--- a/packages/ecosystem/sitemap/dist/index.js
+++ b/packages/ecosystem/sitemap/dist/index.js
@@ -1,0 +1,7 @@
+// src/define-config.ts
+function defineSitemapConfig(config) {
+  return config;
+}
+export {
+  defineSitemapConfig
+};

--- a/packages/ecosystem/sitemap/package.json
+++ b/packages/ecosystem/sitemap/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@rasenganjs/sitemap",
+  "private": false,
+  "version": "1.0.0-beta.1",
+  "description": "Post-build sitemap.xml generation for Rasengan.js frontend apps (RFC-0011).",
+  "type": "module",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/rasengan-dev/rasenganjs",
+    "directory": "packages/ecosystem/sitemap"
+  },
+  "author": {
+    "name": "dilane3",
+    "email": "komboudilane125@gmail.com",
+    "url": "https://dilane3.com",
+    "twitter": "https://twitter.com/dilanekombou",
+    "github": "https://github.com/dilane3"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "bin": {
+    "rasengan-sitemap": "bin.js"
+  },
+  "files": [
+    "dist/",
+    "bin.js",
+    "CHANGELOG.md",
+    "README.md"
+  ],
+  "scripts": {
+    "build:clean": "rimraf ./dist",
+    "build": "pnpm build:clean && tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "pack": "pnpm pack --pack-destination ./release",
+    "deploy": "pnpm publish --access public",
+    "deploy:beta": "pnpm run deploy --tag beta"
+  },
+  "peerDependencies": {
+    "rasengan": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "rasengan": "workspace:*",
+    "rimraf": "^6.1.3",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3",
+    "vitest": "^4.1.9"
+  }
+}

--- a/packages/ecosystem/sitemap/src/build-config.ts
+++ b/packages/ecosystem/sitemap/src/build-config.ts
@@ -1,0 +1,54 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+export interface RasenganRedirect {
+  source: string;
+  destination: string;
+  permanent?: boolean;
+}
+
+export interface RasenganBuildOptions {
+  buildDirectory: string;
+  staticDirectory: string;
+  clientPathDirectory: string;
+  serverPathDirectory: string;
+  assetPathDirectory: string;
+}
+
+export interface RasenganBuildConfig {
+  buildOptions: RasenganBuildOptions;
+  ssr: boolean;
+  prerender: boolean;
+  redirects: RasenganRedirect[];
+}
+
+/**
+ * Locate and parse the `config.json` `rasengan build` writes, same file
+ * `@rasenganjs/vercel`/`@rasenganjs/netlify` already read post-build. Tries
+ * both locations those adapters try (SSR/SSG puts it under `client/`, SPA
+ * doesn't).
+ */
+export async function loadBuildConfig(
+  cwd: string
+): Promise<RasenganBuildConfig> {
+  const candidates = [
+    path.posix.join(cwd, 'dist', 'client', 'assets', 'config.json'),
+    path.posix.join(cwd, 'dist', 'assets', 'config.json'),
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      await access(candidate);
+      const text = await readFile(candidate, 'utf-8');
+      const parsed = JSON.parse(text) as RasenganBuildConfig;
+      return { ...parsed, redirects: parsed.redirects ?? [] };
+    } catch {
+      // Try the next candidate.
+    }
+  }
+
+  throw new Error(
+    'Could not find dist/client/assets/config.json or dist/assets/config.json. ' +
+      'Run `rasengan build` before `rasengan-sitemap`.'
+  );
+}

--- a/packages/ecosystem/sitemap/src/cli.ts
+++ b/packages/ecosystem/sitemap/src/cli.ts
@@ -1,0 +1,61 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { loadSitemapConfig } from './config-loader.js';
+import { loadBuildConfig } from './build-config.js';
+import { collectRoutePaths } from './collect-routes.js';
+import { resolveOutputDirectory } from './output-dir.js';
+import { buildSitemapXml } from './generate-xml.js';
+
+const LOG_PREFIX = '[rasengan-sitemap]';
+
+function buildRobotsTxt(siteUrl: string): string {
+  const sitemapUrl = new URL('sitemap.xml', siteUrl).toString();
+  return `User-agent: *\nAllow: /\n\nSitemap: ${sitemapUrl}\n`;
+}
+
+export async function main(): Promise<void> {
+  const cwd = process.cwd();
+
+  try {
+    const config = await loadSitemapConfig(cwd);
+    const build = await loadBuildConfig(cwd);
+
+    if (!build.prerender) {
+      throw new Error(
+        'rasengan-sitemap currently only supports SSG (prerender: true) apps. ' +
+          'SSR/SPA support is planned for a future release.'
+      );
+    }
+
+    const { paths, warnings } = await collectRoutePaths(cwd, build);
+
+    for (const warning of warnings) {
+      console.warn(`${LOG_PREFIX} warning: ${warning}`);
+    }
+
+    const redirectSources = new Set(
+      build.redirects.map((redirect) => redirect.source)
+    );
+    const xml = await buildSitemapXml(paths, redirectSources, config);
+
+    const outputDir = resolveOutputDirectory(cwd, build);
+    await mkdir(outputDir, { recursive: true });
+
+    const sitemapPath = path.posix.join(outputDir, 'sitemap.xml');
+    await writeFile(sitemapPath, xml, 'utf-8');
+
+    console.log(`${LOG_PREFIX} Wrote ${paths.length} URLs to ${sitemapPath}`);
+
+    if (config.generateRobotsTxt) {
+      const robotsPath = path.posix.join(outputDir, 'robots.txt');
+      await writeFile(robotsPath, buildRobotsTxt(config.siteUrl), 'utf-8');
+      console.log(`${LOG_PREFIX} Wrote ${robotsPath}`);
+    }
+  } catch (err) {
+    console.error(`${LOG_PREFIX} ${(err as Error).message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/packages/ecosystem/sitemap/src/cli.ts
+++ b/packages/ecosystem/sitemap/src/cli.ts
@@ -21,10 +21,13 @@ export async function main(): Promise<void> {
     const config = await loadSitemapConfig(cwd);
     const build = await loadBuildConfig(cwd);
 
-    if (!build.prerender) {
+    if (!build.prerender && !build.ssr) {
       throw new Error(
-        'rasengan-sitemap currently only supports SSG (prerender: true) apps. ' +
-          'SSR/SPA support is planned for a future release.'
+        'rasengan-sitemap needs a server-rendered route bundle to enumerate ' +
+          'routes, which pure SPA builds (ssr: false, prerender: false) do not ' +
+          'produce. Temporarily set `ssr: true` in rasengan.config.js, run ' +
+          '`rasengan build`, then `rasengan-sitemap` (the route tree is the ' +
+          'same regardless of ssr/spa, only the rendering strategy differs).'
       );
     }
 

--- a/packages/ecosystem/sitemap/src/collect-routes.ts
+++ b/packages/ecosystem/sitemap/src/collect-routes.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { generateRoutes, getAllRoutesPath } from 'rasengan';
+import type { RouterComponent } from 'rasengan';
+import type { RasenganBuildConfig } from './build-config.js';
+
+export interface CollectedRoutes {
+  paths: string[];
+  warnings: string[];
+}
+
+/**
+ * Enumerate every concrete URL the app can produce, reusing the exact
+ * route-walking `preRenderApp()` itself already relies on
+ * (`generateRoutes()` then `getAllRoutesPath()`). `_api/` routes are
+ * structurally impossible to appear here: they're dispatched through a
+ * completely separate Futon router, never through `RouterComponent`/
+ * `generateRoutes()`, so no filter is needed for them.
+ */
+export async function collectRoutePaths(
+  cwd: string,
+  build: RasenganBuildConfig
+): Promise<CollectedRoutes> {
+  // config.json's own buildOptions.serverPathDirectory is always 'server'
+  // as written by the framework's build plugin, even in prerender mode —
+  // dist/server/ is never actually built when prerender is true, only
+  // dist/prerender/ is (see core/config/vite/defaults.ts's builder.buildApp:
+  // the ssr environment only builds `if (config.ssr && !config.prerender)`).
+  // Override here to match reality instead of trusting the stored value.
+  const serverPathDirectory = build.prerender
+    ? 'prerender'
+    : build.buildOptions.serverPathDirectory;
+
+  const appRouterPath = path.posix.join(
+    cwd,
+    build.buildOptions.buildDirectory,
+    serverPathDirectory,
+    'app.router.js'
+  );
+
+  let AppRouter: RouterComponent;
+  try {
+    const mod = await import(pathToFileURL(appRouterPath).href);
+    // File-based routing's app.router.js exports the (async) flatRoutes()
+    // call result directly, so `default` is a Promise<RouterComponent>
+    // rather than a RouterComponent — same await pre-render.tsx does.
+    AppRouter = (await (mod.default ?? mod)) as RouterComponent;
+  } catch (err) {
+    throw new Error(
+      `Could not import the built router at ${appRouterPath}. ` +
+        `Make sure \`rasengan build\` completed successfully.\n${(err as Error).message}`
+    );
+  }
+
+  const routeTree = generateRoutes(AppRouter);
+  const { paths, error } = await getAllRoutesPath(routeTree);
+
+  // '*' is the framework's catch-all/404 route, never a real indexable page.
+  const filtered = paths.filter((p) => !p.includes('*'));
+
+  return { paths: filtered, warnings: Array.from(error) };
+}

--- a/packages/ecosystem/sitemap/src/config-loader.ts
+++ b/packages/ecosystem/sitemap/src/config-loader.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import type { SitemapConfig } from './types.js';
+
+/**
+ * Load `rasengan-sitemap.config.js` from the project root. Plain JS only
+ * for v1, matching `rasengan.config.js`'s own convention (no TS
+ * transpilation step in this CLI).
+ */
+export async function loadSitemapConfig(cwd: string): Promise<SitemapConfig> {
+  const configPath = path.posix.join(cwd, 'rasengan-sitemap.config.js');
+
+  let mod: { default?: SitemapConfig } & Partial<SitemapConfig>;
+  try {
+    mod = await import(pathToFileURL(configPath).href);
+  } catch (err) {
+    throw new Error(
+      `Could not load rasengan-sitemap.config.js at ${configPath}. ` +
+        `Create one exporting defineSitemapConfig({ siteUrl: '...' }).\n` +
+        `${(err as Error).message}`
+    );
+  }
+
+  const config = (mod.default ?? (mod as SitemapConfig)) as SitemapConfig;
+
+  if (!config?.siteUrl) {
+    throw new Error(
+      '`siteUrl` is required in rasengan-sitemap.config.js, e.g. ' +
+        "defineSitemapConfig({ siteUrl: 'https://example.com' })."
+    );
+  }
+
+  return config;
+}

--- a/packages/ecosystem/sitemap/src/define-config.ts
+++ b/packages/ecosystem/sitemap/src/define-config.ts
@@ -1,0 +1,10 @@
+import type { SitemapConfig } from './types.js';
+
+/**
+ * Typed pass-through helper for `rasengan-sitemap.config.js`. Returns the
+ * same object you pass in, with type-checking, same shape as `rasengan`'s
+ * own `defineConfig()`.
+ */
+export function defineSitemapConfig(config: SitemapConfig): SitemapConfig {
+  return config;
+}

--- a/packages/ecosystem/sitemap/src/generate-xml.ts
+++ b/packages/ecosystem/sitemap/src/generate-xml.ts
@@ -1,0 +1,71 @@
+import type { SitemapConfig, SitemapEntry } from './types.js';
+
+/** Minimal glob support (`*` only) for `exclude` patterns, no dependency. */
+function matchGlob(pattern: string, value: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(`^${escaped.replace(/\*/g, '.*')}$`);
+  return regex.test(value);
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function renderUrl(entry: SitemapEntry, siteUrl: string): string {
+  const loc = new URL(entry.loc, siteUrl).toString();
+  const lines = [`    <loc>${escapeXml(loc)}</loc>`];
+
+  if (entry.changefreq) {
+    lines.push(`    <changefreq>${entry.changefreq}</changefreq>`);
+  }
+  if (entry.priority !== undefined) {
+    lines.push(`    <priority>${entry.priority}</priority>`);
+  }
+
+  return `  <url>\n${lines.join('\n')}\n  </url>`;
+}
+
+/**
+ * Build the sitemap.xml body: filters out redirect sources and
+ * `exclude`-matched routes, applies `transform` (or the static
+ * `changefreq`/`priority` defaults) to everything else.
+ */
+export async function buildSitemapXml(
+  routePaths: string[],
+  redirectSources: Set<string>,
+  config: SitemapConfig
+): Promise<string> {
+  const exclude = config.exclude ?? [];
+
+  const entries: SitemapEntry[] = [];
+  for (const routePath of routePaths) {
+    if (redirectSources.has(routePath)) continue;
+    if (exclude.some((pattern) => matchGlob(pattern, routePath))) continue;
+
+    const entry = config.transform
+      ? await config.transform(routePath)
+      : {
+          loc: routePath,
+          changefreq: config.changefreq,
+          priority: config.priority,
+        };
+
+    entries.push(entry);
+  }
+
+  const urls = entries
+    .map((entry) => renderUrl(entry, config.siteUrl))
+    .join('\n');
+
+  return (
+    '<?xml version="1.0" encoding="UTF-8"?>\n' +
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n' +
+    `${urls}\n` +
+    '</urlset>\n'
+  );
+}

--- a/packages/ecosystem/sitemap/src/index.ts
+++ b/packages/ecosystem/sitemap/src/index.ts
@@ -1,0 +1,2 @@
+export { defineSitemapConfig } from './define-config.js';
+export type { SitemapConfig, SitemapEntry, ChangeFrequency } from './types.js';

--- a/packages/ecosystem/sitemap/src/output-dir.ts
+++ b/packages/ecosystem/sitemap/src/output-dir.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import type { RasenganBuildConfig } from './build-config.js';
+
+/**
+ * Same directory-selection logic `@rasenganjs/vercel`'s `copyStaticFiles()`
+ * already uses: prerender output lives in a top-level `static/` sibling of
+ * `dist/`, SSR output's client half lives in `dist/client/`, SPA output is
+ * the bare `dist/`.
+ */
+export function resolveOutputDirectory(
+  cwd: string,
+  build: RasenganBuildConfig
+): string {
+  if (build.prerender) {
+    return path.posix.join(cwd, build.buildOptions.staticDirectory);
+  }
+
+  if (build.ssr) {
+    return path.posix.join(
+      cwd,
+      build.buildOptions.buildDirectory,
+      build.buildOptions.clientPathDirectory
+    );
+  }
+
+  return path.posix.join(cwd, build.buildOptions.buildDirectory);
+}

--- a/packages/ecosystem/sitemap/src/types.ts
+++ b/packages/ecosystem/sitemap/src/types.ts
@@ -1,0 +1,33 @@
+export type ChangeFrequency =
+  'always' | 'hourly' | 'daily' | 'weekly' | 'monthly' | 'yearly' | 'never';
+
+export interface SitemapEntry {
+  /** Route path (e.g. `/blog/hello`) or a full absolute URL. */
+  loc: string;
+  changefreq?: ChangeFrequency;
+  /** 0.0 to 1.0. */
+  priority?: number;
+}
+
+export interface SitemapConfig {
+  /**
+   * Absolute base URL of the deployed site, e.g. `https://rasengan.dev`.
+   * Required: nothing in the framework itself has a concept of a
+   * site-wide base URL to fall back on.
+   */
+  siteUrl: string;
+  /** Glob patterns matched against each route path, e.g. `/admin/*`. */
+  exclude?: string[];
+  /** Static default applied to every route unless `transform` overrides it. */
+  changefreq?: ChangeFrequency;
+  /** Static default applied to every route unless `transform` overrides it. */
+  priority?: number;
+  /** Per-route override, called once per route path that survives `exclude`. */
+  transform?: (path: string) => SitemapEntry | Promise<SitemapEntry>;
+  /**
+   * Append a `Sitemap:` line to an existing `robots.txt`, or write a
+   * minimal one if none exists. Off by default so an existing
+   * hand-written robots.txt is never silently touched.
+   */
+  generateRobotsTxt?: boolean;
+}

--- a/packages/ecosystem/sitemap/tsconfig.json
+++ b/packages/ecosystem/sitemap/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": false,
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/ecosystem/sitemap/tsup.config.ts
+++ b/packages/ecosystem/sitemap/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    cli: 'src/cli.ts',
+  },
+  format: ['esm', 'cjs'],
+  dts: {
+    entry: {
+      index: 'src/index.ts',
+    },
+  },
+  clean: true,
+  external: ['rasengan'],
+});

--- a/packages/framework/rasengan/src/routing/index.ts
+++ b/packages/framework/rasengan/src/routing/index.ts
@@ -16,6 +16,8 @@ export {
   defineRoutesGroup,
   defineStaticPaths,
   flatRoutes,
+  generateRoutes,
+  getAllRoutesPath,
 } from './utils/index.js';
 export { RouterComponent } from './interfaces.js';
 export {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1080,7 +1080,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ecosystem/i18n:
     dependencies:
@@ -1158,7 +1158,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ecosystem/kage-demo:
     dependencies:
@@ -1226,7 +1226,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+
+  packages/ecosystem/sitemap:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.0
+        version: 22.20.1
+      rasengan:
+        specifier: workspace:*
+        version: link:../../framework/rasengan
+      rimraf:
+        specifier: ^6.1.3
+        version: 6.1.3
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.26)(tsx@4.23.1)(typescript@5.9.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/ecosystem/theme:
     dependencies:
@@ -1264,7 +1285,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
       zod:
         specifier: ^3.23.0
         version: 3.25.76
@@ -1297,7 +1318,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
       ws:
         specifier: ^8.21.0
         version: 8.21.1
@@ -1318,7 +1339,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/framework/mdx:
     dependencies:
@@ -1461,7 +1482,7 @@ importers:
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
   packages/framework/rasengan-server:
     dependencies:
@@ -1505,7 +1526,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
 
 packages:
 
@@ -5149,7 +5170,6 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
-    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   light-my-request@6.6.0:
@@ -13253,7 +13273,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@22.20.1)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))
@@ -13282,7 +13302,7 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9(vitest@4.1.10))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)):
+  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(@vitest/coverage-v8@4.1.9)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,6 +165,9 @@ importers:
       '@rasenganjs/serve':
         specifier: beta
         version: 2.0.0-beta.2(rasengan@2.0.0-beta.4(@rasenganjs/mdx@1.2.2(@types/react@19.2.17)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rollup@4.62.2)(shiki@4.3.1)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)))(@types/node@24.13.3)(babel-plugin-react-compiler@1.0.0)(less@4.8.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(sass@1.101.7)(stylus@0.64.0)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(less@4.8.0)(sass@1.101.7)(stylus@0.64.0)(tsx@4.23.1)(yaml@2.9.0)))
+      '@rasenganjs/sitemap':
+        specifier: workspace:*
+        version: link:../../packages/ecosystem/sitemap
       '@rasenganjs/theme':
         specifier: ^1.1.0
         version: 1.1.0(react@19.2.8)


### PR DESCRIPTION
## 🔗 Related Issue

<!-- Link the tracking issue/discussion for RFC-0011 here -->

## 🚀 Type of Change

- [x] 📖 Documentation (Updates to README, API docs, or comments)
- [ ] 🐞 Bug Fix (Non-breaking fix for an issue)
- [ ] ⚡ Performance (Optimizations for faster execution)
- [x] ✨ Feature (New functionality without breaking changes)
- [ ] 🔧 Refactor (Code improvements without changing behavior)
- [ ] 🧹 Chore (Build process, tooling, dependencies)
- [ ] ⚠️ Breaking Change (Modifications that impact existing usage)

## 📜 Description

Adds `@rasenganjs/sitemap`, a post-build CLI (`rasengan-sitemap`) that generates a spec-compliant `sitemap.xml` for `rasengan` frontend apps. Runs as a genuinely separate step after `rasengan build` (`rasengan build && rasengan-sitemap`), not a Vite plugin, Rollup's `closeBundle` hook has no cross-plugin ordering guarantee, so a plugin-based approach can't reliably observe `rasengan()`'s finished output. Full design in [RFC-0011](./proposals/RFC-0011-Sitemap-Generation.md).

**Scope:** the `rasengan` frontend framework only. Futon and `@rasenganjs/server` are backend frameworks with no "page" concept, so a sitemap doesn't apply to them.

**What's implemented:**
- `defineSitemapConfig()` + a `rasengan-sitemap.config.js` config file (`siteUrl` required, optional `changefreq`/`priority` defaults, a `transform` override function, glob `exclude` patterns, opt-in `robots.txt` generation).
- Route enumeration reuses `generateRoutes`/`getAllRoutesPath`, the exact same route-walking logic `preRenderApp()` already relies on for prerendering. Both newly exported from `rasengan`'s public API (previously internal-only).
- Both **`prerender: true`** (SSG) and **`ssr: true`** builds are supported, writing into whichever directory the app actually produced (`static/` or `dist/client/`), mirroring `@rasenganjs/vercel`'s/`@rasenganjs/netlify`'s own directory-selection logic.
- Automatic exclusion of the catch-all `*`/404 route, `_api/` routes (excluded by construction, a separate router, never part of the page route tree, no filter needed), and any route matching a redirect `source` in `rasengan.config.js`.
- Pure SPA builds (`ssr: false`, `prerender: false`) are not supported yet, no server-rendered route bundle exists to enumerate routes from with a clear error message pointing at the workaround (temporarily set `ssr: true`).

**Verified against real builds**, not just unit tests: ran the actual CLI against a real playground app in both prerender and SSR modes (including a real redirect entry), and confirmed the generated `sitemap.xml`'s URL set exactly matched the real build output, with the redirect's source path correctly excluded and no `*`/`_api/` leaks.

**Docs:** a package doc page, its nav entry un-flagged from "coming soon," a blog post link fixed, and `@rasenganjs/sitemap` configured (not yet functionally active, pending a `rasengan` release containing the new exports) in docs-v2 itself as a real dogfooding example.

## 📸 Screenshots / Demos (if applicable)

N/A: CLI/build-tool package, no UI surface.

## ✅ Checklist

- [ ] I have linked a related issue or discussion.
- [x] I have updated documentation if needed. (RFC-0011, package `README.md`, `CHANGELOG.md`, docs-v2 page + nav entry)
- [x] I have tested the changes in a real project. (real playground builds, prerender and SSR modes, verified URL-set-exact-match against actual build output)
- [x] I have added tests or confirmed that existing tests pass. (full `rasengan` suite passes after the `generateRoutes`/`getAllRoutesPath` export change)

## 💡 Additional Notes

- **Scope callout for reviewers:** this branch also carries some pre-existing, unrelated docs-v2 work that was sitting uncommitted in the working tree when this feature branch was created and got swept into these commits, the responsive sidebar/navbar controllers (`layout.tsx`, `navbar.tsx`, `store/navigation`, `store/mobile-menu`), the "no em-dash in generated interface text" house rule in `CLAUDE.md`, and `<a>`→`<Link>`/em-dash normalization across the package doc pages. None of it conflicts with the sitemap work, but happy to split it into a separate PR first if you'd prefer a narrower diff to review.
- `@rasenganjs/sitemap` won't actually function end-to-end for a consumer until `rasengan` itself is published with the `generateRoutes`/`getAllRoutesPath` exports this package depends on, currently only present in the workspace-linked local build.