### PR TITLE
feat(futon,runtime): forward Workers bindings and ExecutionContext, add typed Env generic

### DIFF
--- a/packages/cli/create-rasengan/CHANGELOG.md
+++ b/packages/cli/create-rasengan/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+## 1.5.0-beta.5 (2026-08-16)
+
+### Features
+
+- **create-rasengan:** remove the rasengan version overwrite logic 1e992d0
+
 ## 1.5.0-beta.4 (2026-07-24)
 
 ### Bug Fixes

--- a/packages/cli/create-rasengan/package.json
+++ b/packages/cli/create-rasengan/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-rasengan",
-  "version": "1.5.0-beta.4",
+  "version": "1.5.0-beta.5",
   "description": "The Rasengan.js CLI tool to generate a new project with a simple template",
   "type": "module",
   "exports": {

--- a/packages/cli/create-rasengan/src/main.ts
+++ b/packages/cli/create-rasengan/src/main.ts
@@ -244,15 +244,15 @@ program
       }
 
       // Getting the version based on the --beta option
-      let versionName = '';
+      // let versionName = '';
 
-      if (experimental) {
-        if (Versions.beta) {
-          versionName = Versions.beta;
-        }
-      } else {
-        versionName = Versions.stable;
-      }
+      // if (experimental) {
+      //   if (Versions.beta) {
+      //     versionName = Versions.beta;
+      //   }
+      // } else {
+      //   versionName = Versions.stable;
+      // }
 
       // Resolve the project kind
       let kind: Kind;
@@ -366,7 +366,7 @@ program
         projectPath,
         templateKey,
         initGit: Boolean(initGit),
-        rasenganVersion: versionName || undefined,
+        // rasenganVersion: versionName || undefined,
       });
     }
   });

--- a/packages/cli/create-rasengan/src/scripts/fetch-starter.ts
+++ b/packages/cli/create-rasengan/src/scripts/fetch-starter.ts
@@ -26,7 +26,7 @@ const spinner = (text: string) =>
  */
 async function rewritePackageJson(
   packageJsonPath: string,
-  { name, rasenganVersion }: { name?: string; rasenganVersion?: string }
+  { name }: { name?: string }
 ) {
   let packageJsonString: string;
 
@@ -39,10 +39,6 @@ async function rewritePackageJson(
   const packageJson = JSON.parse(packageJsonString);
 
   if (name) packageJson.name = name;
-
-  if (rasenganVersion && packageJson.dependencies?.rasengan) {
-    packageJson.dependencies.rasengan = rasenganVersion;
-  }
 
   await fs.writeFile(packageJsonPath, JSON.stringify(packageJson, null, 2));
 }
@@ -183,14 +179,11 @@ export default async function fetchStarterTemplate(options: {
     // every kind, including the mono-repo's workspace root)
     await rewritePackageJson(path.join(projectPath, 'package.json'), {
       name: nameOfProject,
-      rasenganVersion,
     });
 
     // The mono-repo template nests a `rasengan` frontend under `web/` —
     // its own package.json also needs the version pin (name stays "web")
-    await rewritePackageJson(path.join(projectPath, 'web', 'package.json'), {
-      rasenganVersion,
-    });
+    await rewritePackageJson(path.join(projectPath, 'web', 'package.json'), {});
 
     // Removing the temporary folder
     rimraf.sync(tmpFolder);

--- a/packages/framework/futon/CHANGELOG.md
+++ b/packages/framework/futon/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Features
+
+- add typed `Env` generic on `Context`/`Futon`/`Handler`/`Middleware` — declare a project's own `Bindings` type and pass it to `new Futon<Bindings>()` for full autocomplete on `ctx.runtime.env` in every handler/middleware registered through `get`/`post`/`put`/`patch`/`delete`/`head`/`options`/`use`, matching Hono's `c.env`; defaults to `Record<string, unknown>` so existing untyped apps compile unchanged (RFC-0013 Phase 2) 946c1b5
+- add `RuntimeContext.executionCtx` (`ExecutionContext.waitUntil`/`passThroughOnException`) and widen `RuntimeContext.env` from `Record<string, string>` to `Record<string, unknown>` — Workers bindings (D1, R2, KV, service bindings, secrets) and fire-and-forget work are now reachable from `ctx.runtime` on every adapter: real `ExecutionContext` on Workerd, a logging stub on Node/Bun (RFC-0013 Phase 1) 2b790f9
+
 ## 1.0.0-beta.4 (2026-08-14)
 
 ### Bug Fixes

--- a/packages/framework/futon/src/__tests__/integration/application.test.ts
+++ b/packages/framework/futon/src/__tests__/integration/application.test.ts
@@ -34,6 +34,26 @@ describe('Futon (integration)', () => {
     expect(await res.json()).toEqual({ hasDb: true });
   });
 
+  it('types ctx.runtime.env from a declared Bindings type (RFC-0013 Phase 2)', async () => {
+    type Bindings = { DB: { prepare: (sql: string) => string } };
+    const db: Bindings['DB'] = { prepare: (sql) => `prepared: ${sql}` };
+
+    const typedApp = new Futon<Bindings>();
+    typedApp.get('/query', async (ctx) => {
+      // No cast, no `as`, no `?.` needed — this line is the actual
+      // compile-time proof: ctx.runtime.env is typed as `Bindings`,
+      // not `Record<string, unknown>`, inside this handler.
+      const result = ctx.runtime.env.DB.prepare('select 1');
+      return json({ result });
+    });
+
+    const req = new Request('http://localhost/query');
+    const res = await typedApp.fetch(req, { env: { DB: db } });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ result: 'prepared: select 1' });
+  });
+
   it('exposes ctx.runtime.executionCtx.waitUntil when provided by the adapter (RFC-0013)', async () => {
     const waitUntil = vi.fn();
     app.get('/wait', async (ctx) => {

--- a/packages/framework/futon/src/__tests__/integration/application.test.ts
+++ b/packages/framework/futon/src/__tests__/integration/application.test.ts
@@ -21,6 +21,33 @@ describe('Futon (integration)', () => {
     expect(await res.json()).toEqual({ message: 'world' });
   });
 
+  it('exposes non-string bindings via ctx.runtime.env (RFC-0013)', async () => {
+    const db = { prepare: () => 'fake-d1-binding' };
+    app.get('/binding', async (ctx) =>
+      json({ hasDb: ctx.runtime.env?.DB === db })
+    );
+
+    const req = new Request('http://localhost/binding');
+    const res = await app.fetch(req, { env: { DB: db } });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ hasDb: true });
+  });
+
+  it('exposes ctx.runtime.executionCtx.waitUntil when provided by the adapter (RFC-0013)', async () => {
+    const waitUntil = vi.fn();
+    app.get('/wait', async (ctx) => {
+      ctx.runtime.executionCtx?.waitUntil(Promise.resolve('usage-event'));
+      return json({ ok: true });
+    });
+
+    const req = new Request('http://localhost/wait');
+    const res = await app.fetch(req, { executionCtx: { waitUntil } });
+
+    expect(res.status).toBe(200);
+    expect(waitUntil).toHaveBeenCalledTimes(1);
+  });
+
   it('responds to a registered POST route', async () => {
     app.post('/data', async () => json({ created: true }));
 

--- a/packages/framework/futon/src/app/index.ts
+++ b/packages/framework/futon/src/app/index.ts
@@ -374,6 +374,7 @@ export class Futon {
     const mergedRuntime: RuntimeContext = {
       ...runtime,
       env: { ...this.env, ...runtime.env },
+      executionCtx: runtime.executionCtx,
       server: runtime.server ?? this.serverInfo,
       assets: runtime.assets ?? this.assets,
     };

--- a/packages/framework/futon/src/app/index.ts
+++ b/packages/framework/futon/src/app/index.ts
@@ -37,6 +37,7 @@
 import type {
   Assets,
   Context,
+  QueryParams,
   RuntimeContext,
   ServerInfo,
 } from '../context/types.js';
@@ -48,8 +49,25 @@ import { Router } from '../router/index.js';
 import { getPathname } from '../router/utils.js';
 import { text } from '../response/utils.js';
 import { HookSystem } from '../hooks/index.js';
+import type { ErrorHandler, Handler } from '../types.js';
 
-export class Futon {
+/**
+ * `Env` is the shape of `ctx.runtime.env` (RFC-0013 Phase 2). Declare
+ * a project's own `Bindings` type and pass it as `new Futon<Bindings>()`
+ * to get full autocomplete on `ctx.runtime.env` in every handler and
+ * middleware registered through this instance, the same ergonomics
+ * as Hono's `c.env`. Defaults to `Record<string, unknown>`, so
+ * `new Futon()` needs no changes.
+ *
+ * `Router`/`Middleware`'s own internals stay untyped for `Env`
+ * (a deliberate scope limit, see RFC-0013's Phase 2 "Open questions")
+ * — routes registered through `.group()` on the raw `Router` returned
+ * by `getRouter()` do not get a typed `ctx.runtime.env`, only routes
+ * registered directly through this class's `get`/`post`/etc. do. The
+ * casts below are safe: `Env` only changes what TypeScript infers for
+ * `ctx.runtime.env`, never the actual object shape at runtime.
+ */
+export class Futon<Env = Record<string, unknown>> {
   private middlewares: Middleware[] = [];
   private router: Router;
 
@@ -128,19 +146,25 @@ export class Futon {
    * app.use("/api", authMiddleware);     // scoped to /api/*
    * ```
    */
-  use(middleware: Middleware): this;
-  use(path: string, middleware: Middleware): this;
-  use(pathOrMiddleware: string | Middleware, middleware?: Middleware): this {
+  use(middleware: Middleware<Env>): this;
+  use(path: string, middleware: Middleware<Env>): this;
+  use(
+    pathOrMiddleware: string | Middleware<Env>,
+    middleware?: Middleware<Env>
+  ): this {
     if (typeof pathOrMiddleware === 'string' && middleware) {
       const path = pathOrMiddleware;
       this.middlewares.push(async (ctx, next) => {
         if (getPathname(ctx.request.url).startsWith(path)) {
-          return middleware(ctx, next);
+          return middleware(
+            ctx as Context<any, Record<string, string>, QueryParams, Env>,
+            next
+          );
         }
         return next();
       });
     } else {
-      this.middlewares.push(pathOrMiddleware as Middleware);
+      this.middlewares.push(pathOrMiddleware as unknown as Middleware);
     }
     this._chain = null;
     return this;
@@ -148,38 +172,59 @@ export class Futon {
 
   // ── Route shortcuts (delegate to internal Router) ──────────
 
-  get(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.get(pattern, handler);
+  get(pattern: string, handler: Handler<Env>): this {
+    this.router.get(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  post(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.post(pattern, handler);
+  post(pattern: string, handler: Handler<Env>): this {
+    this.router.post(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  put(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.put(pattern, handler);
+  put(pattern: string, handler: Handler<Env>): this {
+    this.router.put(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  patch(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.patch(pattern, handler);
+  patch(pattern: string, handler: Handler<Env>): this {
+    this.router.patch(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  delete(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.delete(pattern, handler);
+  delete(pattern: string, handler: Handler<Env>): this {
+    this.router.delete(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  head(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.head(pattern, handler);
+  head(pattern: string, handler: Handler<Env>): this {
+    this.router.head(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
-  options(pattern: string, handler: (ctx: Context) => Promise<Response>): this {
-    this.router.options(pattern, handler);
+  options(pattern: string, handler: Handler<Env>): this {
+    this.router.options(
+      pattern,
+      handler as unknown as (ctx: Context) => Promise<Response>
+    );
     return this;
   }
 
@@ -223,9 +268,9 @@ export class Futon {
 
   // ── Error / 404 handlers ───────────────────────────────────
 
-  private notFoundHandler?: (ctx: Context) => Promise<Response>;
-  private fallbackHandler?: (ctx: Context) => Promise<Response>;
-  private errorHandler?: (error: Error, ctx: Context) => Promise<Response>;
+  private notFoundHandler?: Handler<Env>;
+  private fallbackHandler?: Handler<Env>;
+  private errorHandler?: ErrorHandler<Env>;
 
   /**
    * Register a custom 404 handler for unmatched routes.
@@ -239,7 +284,7 @@ export class Futon {
    *
    * If not set, returns a plain-text "Not Found" response.
    */
-  notFound(handler: (ctx: Context) => Promise<Response>): this {
+  notFound(handler: Handler<Env>): this {
     this.notFoundHandler = handler;
     return this;
   }
@@ -260,7 +305,7 @@ export class Futon {
    *
    * Takes priority over `notFound()` when both are registered.
    */
-  fallback(handler: (ctx: Context) => Promise<Response>): this {
+  fallback(handler: Handler<Env>): this {
     this.fallbackHandler = handler;
     return this;
   }
@@ -271,7 +316,7 @@ export class Futon {
    * If not set, returns a plain-text "Internal Server Error"
    * response with status 500.
    */
-  onError(handler: (error: Error, ctx: Context) => Promise<Response>): this {
+  onError(handler: ErrorHandler<Env>): this {
     this.errorHandler = handler;
     return this;
   }
@@ -367,18 +412,23 @@ export class Futon {
    */
   async fetch(
     request: Request,
-    runtime: RuntimeContext = {}
+    runtime: RuntimeContext<Env> = {}
   ): Promise<Response> {
     // Merge app-level props into the runtime context so they
     // flow through to every handler and middleware via ctx.runtime.*.
-    const mergedRuntime: RuntimeContext = {
+    // The env merge is cast to `Env`: `this.env` (dotenv-loaded string
+    // vars) and `runtime.env` (adapter-provided, real bindings on
+    // Workerd) are plumbing, not a type the merge itself can prove —
+    // a project's own `Bindings` type is expected to cover whatever
+    // keys actually end up here.
+    const mergedRuntime: RuntimeContext<Env> = {
       ...runtime,
-      env: { ...this.env, ...runtime.env },
+      env: { ...this.env, ...runtime.env } as Env,
       executionCtx: runtime.executionCtx,
       server: runtime.server ?? this.serverInfo,
       assets: runtime.assets ?? this.assets,
     };
-    const ctx = createContext(request, {}, mergedRuntime);
+    const ctx = createContext<Env>(request, {}, mergedRuntime);
 
     // Fire beforeRequest hook (errors here are swallowed per hook spec).
     // Guarded so hookless apps skip the async-call overhead entirely.
@@ -411,7 +461,7 @@ export class Futon {
     let response: Response;
 
     try {
-      response = await chain(ctx, finalHandler);
+      response = await chain(ctx as unknown as Context, finalHandler);
     } catch (error) {
       // Fire onError hook
       if (error instanceof Error && this.hooks.has('onError')) {

--- a/packages/framework/futon/src/context/index.ts
+++ b/packages/framework/futon/src/context/index.ts
@@ -15,16 +15,16 @@ import { parseQueryString } from '../router/utils.js';
  * `response` is lazily created on first access — if no handler
  * uses the chainable API, no builder is allocated.
  */
-export function createContext(
+export function createContext<Env = Record<string, unknown>>(
   request: Request,
   params: Record<string, string> = {},
-  runtime: RuntimeContext = {}
-): Context {
+  runtime: RuntimeContext<Env> = {}
+): Context<any, Record<string, string>, QueryParams, Env> {
   const state: Record<string, unknown> = {};
   let _query: QueryParams | undefined;
   let _response: ResponseBuilder | undefined;
 
-  const ctx: Context = {
+  const ctx: Context<any, Record<string, string>, QueryParams, Env> = {
     request,
     req: request,
     body: undefined,

--- a/packages/framework/futon/src/context/types.ts
+++ b/packages/framework/futon/src/context/types.ts
@@ -11,6 +11,28 @@
  */
 
 /**
+ * Fire-and-forget lifecycle handle for work that should not delay
+ * the response (RFC-0013).
+ *
+ * On Workerd this is backed by the platform's real `ExecutionContext`
+ * (`waitUntil` keeps the isolate alive until the promise settles).
+ * On Node/Bun, where no such concept exists, the adapter provides a
+ * stub that still runs the promise to completion and logs rejections
+ * instead of leaving them unhandled — so the same `ctx.runtime.executionCtx?.waitUntil(...)`
+ * call is safe to write once and run on every runtime.
+ */
+export interface ExecutionContext {
+  /** Extend the request's lifetime until `promise` settles. */
+  waitUntil(promise: Promise<unknown>): void;
+  /**
+   * Workerd-only: report an unhandled exception without failing the
+   * response that already started streaming. Not implemented by
+   * every adapter — check for its presence before calling it.
+   */
+  passThroughOnException?(): void;
+}
+
+/**
  * Runtime environment information.
  * This is the only platform-specific concept in Context.
  * It lets the same handler code run in Node, Bun, Deno,
@@ -18,7 +40,22 @@
  * (optionally) platform bindings.
  */
 export interface RuntimeContext {
-  env?: Record<string, string>;
+  /**
+   * Environment variables and, on Workerd, platform bindings
+   * (D1 databases, R2 buckets, KV namespaces, service bindings,
+   * secrets). Typed loosely (`unknown` values) here since a binding
+   * is a live object, not a string — see RFC-0013 for the follow-up
+   * that lets a project declare its own typed `Bindings` shape.
+   */
+  env?: Record<string, unknown>;
+
+  /**
+   * Fire-and-forget work handle (RFC-0013). Populated by every
+   * adapter, real `ExecutionContext` on Workerd, a logging stub on
+   * Node/Bun. Absent only if a Futon app is invoked directly via
+   * `app.fetch(request)` outside of any adapter (e.g. in a unit test).
+   */
+  executionCtx?: ExecutionContext;
 
   /**
    * Server info — populated by the adapter when the

--- a/packages/framework/futon/src/context/types.ts
+++ b/packages/framework/futon/src/context/types.ts
@@ -39,15 +39,16 @@ export interface ExecutionContext {
  * Cloudflare Workers, etc. by carrying env vars and
  * (optionally) platform bindings.
  */
-export interface RuntimeContext {
+export interface RuntimeContext<Env = Record<string, unknown>> {
   /**
    * Environment variables and, on Workerd, platform bindings
    * (D1 databases, R2 buckets, KV namespaces, service bindings,
-   * secrets). Typed loosely (`unknown` values) here since a binding
-   * is a live object, not a string — see RFC-0013 for the follow-up
-   * that lets a project declare its own typed `Bindings` shape.
+   * secrets). Defaults to `Record<string, unknown>` — a project that
+   * wants full autocomplete declares its own `Bindings` type and
+   * passes it to `new Futon<Bindings>()` (RFC-0013 Phase 2), which
+   * flows here without this interface ever needing to know its shape.
    */
-  env?: Record<string, unknown>;
+  env?: Env;
 
   /**
    * Fire-and-forget work handle (RFC-0013). Populated by every
@@ -163,11 +164,17 @@ import type { ResponseBuilder } from '../response/builder.js';
  * @typeParam Body   — Typed request body (set by body parser + validation)
  * @typeParam Params — Typed URL path parameters
  * @typeParam Query  — Typed query parameters (intersected with callable access)
+ * @typeParam Env    — Typed `ctx.runtime.env` bindings (RFC-0013 Phase 2).
+ *   Placed last, after the three existing parameters, on purpose: an
+ *   existing 3-argument `Context<Body, Params, Query>` call site (e.g.
+ *   `@rasenganjs/server`'s router) keeps compiling unchanged, `Env`
+ *   simply falls back to its default.
  */
 export interface Context<
   Body = any,
   Params = Record<string, string>,
   Query = QueryParams,
+  Env = Record<string, unknown>,
 > {
   /** The incoming Web API Request */
   request: Request;
@@ -206,7 +213,7 @@ export interface Context<
   query: Query & QueryParams;
 
   /** Runtime environment info */
-  runtime: RuntimeContext;
+  runtime: RuntimeContext<Env>;
 
   /**
    * Chainable response builder.

--- a/packages/framework/futon/src/middlewares/index.ts
+++ b/packages/framework/futon/src/middlewares/index.ts
@@ -1,4 +1,4 @@
-import type { Context } from '../context/types.js';
+import type { Context, QueryParams } from '../context/types.js';
 
 /**
  * Middleware is the core abstraction for the request pipeline.
@@ -25,7 +25,7 @@ import type { Context } from '../context/types.js';
  * };
  * ```
  */
-export type Middleware = (
-  ctx: Context,
+export type Middleware<Env = Record<string, unknown>> = (
+  ctx: Context<any, Record<string, string>, QueryParams, Env>,
   next: () => Promise<Response>
 ) => Promise<Response>;

--- a/packages/framework/futon/src/types.ts
+++ b/packages/framework/futon/src/types.ts
@@ -1,3 +1,5 @@
+import type { Context, QueryParams } from './context/types.js';
+
 /**
  * A FetchHandler is the fundamental request handler primitive.
  * It accepts a Request and a optional Runtime Adapter and
@@ -10,4 +12,35 @@
 export type FetchHandler = (
   request: Request,
   runtime?: any
+) => Promise<Response>;
+
+/**
+ * A typed route handler (RFC-0013 Phase 2).
+ *
+ * `Env` is the shape of `ctx.runtime.env` — declare a project's own
+ * `Bindings` type and pass it to `new Futon<Bindings>()` to get full
+ * autocomplete here, the same ergonomics as Hono's `c.env`. Defaults
+ * to `Record<string, unknown>` so an untyped `new Futon()` needs no
+ * changes.
+ *
+ * @example
+ * ```ts
+ * type Bindings = { DB: D1Database };
+ * const app = new Futon<Bindings>();
+ *
+ * app.get("/products", async (ctx) => {
+ *   const rows = await ctx.runtime.env.DB.prepare("select * from products").all();
+ *   return json(rows);
+ * });
+ * ```
+ */
+export type Handler<
+  Env = Record<string, unknown>,
+  Params = Record<string, string>,
+> = (ctx: Context<any, Params, QueryParams, Env>) => Promise<Response>;
+
+/** Signature accepted by `Futon.onError()` (RFC-0013 Phase 2). */
+export type ErrorHandler<Env = Record<string, unknown>> = (
+  error: Error,
+  ctx: Context<any, Record<string, string>, QueryParams, Env>
 ) => Promise<Response>;

--- a/packages/platform/runtime/CHANGELOG.md
+++ b/packages/platform/runtime/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Features
+
+- `WorkerdProdAdapter.fetchHandler` now forwards `env` and `ctx` (`ExecutionContext`) into Futon's `RuntimeContext` on every request, and defaults `passthrough` to `true` — the Service Worker registration format (`self.addEventListener('fetch', ...)`) never receives `env` from workerd by platform design, so Module Worker format (`export default { fetch }`) is now the default rather than an opt-in, otherwise a deployed Futon app could not read a single binding (D1, R2, KV, service bindings, secrets) (RFC-0013 Phase 1) 2b790f9
+- Node and Bun adapters (dev + prod) now pass a `RuntimeContext.executionCtx` stub into every `app.fetch()` call — a fire-and-forget `waitUntil` that runs the promise to completion and logs rejections instead of leaving them unhandled, so `ctx.runtime.executionCtx?.waitUntil(...)` is safe to call the same way on every runtime (RFC-0013 Phase 1) 2b790f9
+
 ## 1.0.0-beta.5 (2026-08-10)
 
 ## 1.0.0-beta.4 (2026-08-10)

--- a/packages/platform/runtime/src/__tests__/unit/bun/dev-adapter.test.ts
+++ b/packages/platform/runtime/src/__tests__/unit/bun/dev-adapter.test.ts
@@ -18,6 +18,23 @@ function createMockApp() {
   };
 }
 
+/** Mock app that records the `runtime` argument every `fetch()` receives. */
+function createRecordingMockApp() {
+  const calls: any[] = [];
+  return {
+    configureServer: () => {},
+    configureAssets: () => {},
+    loadEnv: () => {},
+    init: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    fetch: (request: Request, runtime?: any) => {
+      calls.push(runtime);
+      return Promise.resolve(new Response('ok'));
+    },
+    calls,
+  };
+}
+
 describe('BunDevAdapter', () => {
   let rootDir: string;
 
@@ -100,6 +117,34 @@ describe('BunDevAdapter', () => {
 
       await adapter.close();
       await servePromise;
+    });
+
+    it('passes a waitUntil-capable executionCtx to app.fetch() (RFC-0013)', async () => {
+      const adapter = new BunDevAdapter({ port: 0, rootDir });
+      const app = createRecordingMockApp();
+
+      const { port, servePromise } = await new Promise<{
+        port: number;
+        servePromise: Promise<void>;
+      }>((resolve) => {
+        const origServe = adapter.serve.bind(adapter);
+        adapter.serve = (a: any, opts?: any) => {
+          const sp = origServe(a, {
+            ...opts,
+            onListening: (i: { port: number }) =>
+              resolve({ port: i.port, servePromise: sp }),
+          });
+          return sp;
+        };
+        adapter.serve(app);
+      });
+
+      await fetch(`http://127.0.0.1:${port}/`);
+      await adapter.close();
+      await servePromise;
+
+      expect(app.calls).toHaveLength(1);
+      expect(typeof app.calls[0].executionCtx.waitUntil).toBe('function');
     });
   });
 });

--- a/packages/platform/runtime/src/__tests__/unit/bun/prod-adapter.test.ts
+++ b/packages/platform/runtime/src/__tests__/unit/bun/prod-adapter.test.ts
@@ -18,6 +18,23 @@ function createMockApp() {
   };
 }
 
+/** Mock app that records the `runtime` argument every `fetch()` receives. */
+function createRecordingMockApp() {
+  const calls: any[] = [];
+  return {
+    configureServer: () => {},
+    configureAssets: () => {},
+    loadEnv: () => {},
+    init: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    fetch: (request: Request, runtime?: any) => {
+      calls.push(runtime);
+      return Promise.resolve(new Response('ok'));
+    },
+    calls,
+  };
+}
+
 describe('BunProdAdapter', () => {
   let rootDir: string;
 
@@ -57,6 +74,34 @@ describe('BunProdAdapter', () => {
       await started;
       await adapter.close();
       await servePromise;
+    });
+
+    it('passes a waitUntil-capable executionCtx to app.fetch() (RFC-0013)', async () => {
+      const adapter = new BunProdAdapter({ port: 0, rootDir });
+      const app = createRecordingMockApp();
+
+      const { port, servePromise } = await new Promise<{
+        port: number;
+        servePromise: Promise<void>;
+      }>((resolve) => {
+        const origServe = adapter.serve.bind(adapter);
+        adapter.serve = (a: any, opts?: any) => {
+          const sp = origServe(a, {
+            ...opts,
+            onListening: (i: { port: number }) =>
+              resolve({ port: i.port, servePromise: sp }),
+          });
+          return sp;
+        };
+        adapter.serve(app);
+      });
+
+      await fetch(`http://127.0.0.1:${port}/`);
+      await adapter.close();
+      await servePromise;
+
+      expect(app.calls).toHaveLength(1);
+      expect(typeof app.calls[0].executionCtx.waitUntil).toBe('function');
     });
   });
 

--- a/packages/platform/runtime/src/__tests__/unit/node/dev-adapter.test.ts
+++ b/packages/platform/runtime/src/__tests__/unit/node/dev-adapter.test.ts
@@ -16,6 +16,23 @@ function createMockApp() {
   };
 }
 
+/** Mock app that records the `runtime` argument every `fetch()` receives. */
+function createRecordingMockApp() {
+  const calls: any[] = [];
+  return {
+    configureServer: () => {},
+    configureAssets: () => {},
+    loadEnv: () => {},
+    init: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    fetch: (request: Request, runtime?: any) => {
+      calls.push(runtime);
+      return Promise.resolve(new Response('ok'));
+    },
+    calls,
+  };
+}
+
 describe('NodeDevAdapter', () => {
   let rootDir: string;
 
@@ -69,6 +86,34 @@ describe('NodeDevAdapter', () => {
 
     await adapter.close();
     await servePromise;
+  });
+
+  it('passes a waitUntil-capable executionCtx to app.fetch() (RFC-0013)', async () => {
+    const adapter = new NodeDevAdapter({ port: 0, rootDir });
+    const app = createRecordingMockApp();
+
+    const { port, servePromise } = await new Promise<{
+      port: number;
+      servePromise: Promise<void>;
+    }>((resolve) => {
+      const origServe = adapter.serve.bind(adapter);
+      adapter.serve = (a: any, opts?: any) => {
+        const sp = origServe(a, {
+          ...opts,
+          onListening: (i: { port: number }) =>
+            resolve({ port: i.port, servePromise: sp }),
+        });
+        return sp;
+      };
+      adapter.serve(app);
+    });
+
+    await fetch(`http://127.0.0.1:${port}/`);
+    await adapter.close();
+    await servePromise;
+
+    expect(app.calls).toHaveLength(1);
+    expect(typeof app.calls[0].executionCtx.waitUntil).toBe('function');
   });
 
   it('provides assets instance', () => {

--- a/packages/platform/runtime/src/__tests__/unit/node/prod-adapter.test.ts
+++ b/packages/platform/runtime/src/__tests__/unit/node/prod-adapter.test.ts
@@ -16,6 +16,23 @@ function createMockApp() {
   };
 }
 
+/** Mock app that records the `runtime` argument every `fetch()` receives. */
+function createRecordingMockApp() {
+  const calls: any[] = [];
+  return {
+    configureServer: () => {},
+    configureAssets: () => {},
+    loadEnv: () => {},
+    init: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    fetch: (request: Request, runtime?: any) => {
+      calls.push(runtime);
+      return Promise.resolve(new Response('ok'));
+    },
+    calls,
+  };
+}
+
 describe('NodeProdAdapter', () => {
   let rootDir: string;
 
@@ -110,5 +127,37 @@ describe('NodeProdAdapter', () => {
     const adapter = new NodeProdAdapter({ rootDir });
     await adapter.close();
     await adapter.close();
+  });
+
+  it('passes a waitUntil-capable executionCtx to app.fetch() (RFC-0013)', async () => {
+    const adapter = new NodeProdAdapter({ port: 0, rootDir });
+    const app = createRecordingMockApp();
+
+    const started = new Promise<{ port: number }>((resolve) => {
+      const origServe = adapter.serve.bind(adapter);
+      adapter.serve = (a: any, opts?: any) =>
+        origServe(a, {
+          ...opts,
+          onListening: (info: { port: number }) => resolve(info),
+        });
+    });
+
+    const servePromise = adapter.serve(app);
+    const { port } = await started;
+
+    await fetch(`http://127.0.0.1:${port}/`);
+    await adapter.close();
+    await servePromise;
+
+    expect(app.calls).toHaveLength(1);
+    const runtime = app.calls[0];
+    expect(typeof runtime.executionCtx.waitUntil).toBe('function');
+
+    // A rejected promise handed to waitUntil must not throw or reject.
+    await expect(
+      Promise.resolve(
+        runtime.executionCtx.waitUntil(Promise.reject(new Error('boom')))
+      )
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/platform/runtime/src/__tests__/unit/workerd/prod-adapter.test.ts
+++ b/packages/platform/runtime/src/__tests__/unit/workerd/prod-adapter.test.ts
@@ -19,6 +19,34 @@ function createMockApp() {
   };
 }
 
+/** Mock app that records the `runtime` argument every `fetch()` receives. */
+function createRecordingMockApp() {
+  const calls: any[] = [];
+  return {
+    configureServer: () => {},
+    configureAssets: () => {},
+    loadEnv: () => {},
+    init: () => Promise.resolve(),
+    destroy: () => Promise.resolve(),
+    fetch: (request: Request, runtime?: any) => {
+      calls.push(runtime);
+      return Promise.resolve(new Response('ok'));
+    },
+    calls,
+  };
+}
+
+function createMockExecutionCtx() {
+  const waitUntilPromises: Promise<unknown>[] = [];
+  return {
+    waitUntil: (p: Promise<unknown>) => {
+      waitUntilPromises.push(p);
+    },
+    passThroughOnException: () => {},
+    waitUntilPromises,
+  };
+}
+
 describe('WorkerdProdAdapter', () => {
   let adapter: WorkerdProdAdapter;
 
@@ -69,6 +97,62 @@ describe('WorkerdProdAdapter', () => {
     expect(await response.text()).toBe('ok');
   });
 
+  it('defaults to passthrough mode when no options are given (RFC-0013)', async () => {
+    adapter = new WorkerdProdAdapter();
+    const app = createMockApp();
+
+    // Resolves (rather than hanging on the never-settling promise the
+    // addEventListener path returns) — proof passthrough is the default.
+    await adapter.serve(app);
+
+    expect(adapter.fetchHandler).not.toBeNull();
+  });
+
+  it('forwards env to app.fetch() as ctx.runtime.env (RFC-0013)', async () => {
+    adapter = new WorkerdProdAdapter();
+    const app = createRecordingMockApp();
+    await adapter.serve(app);
+
+    const env = { DB: { prepare: () => {} }, SECRET: 'shh' };
+    await adapter.fetchHandler!(new Request('http://test/'), env);
+
+    expect(app.calls).toHaveLength(1);
+    expect(app.calls[0].env).toBe(env);
+  });
+
+  it('forwards ctx.waitUntil/passThroughOnException as ctx.runtime.executionCtx (RFC-0013)', async () => {
+    adapter = new WorkerdProdAdapter();
+    const app = createRecordingMockApp();
+    await adapter.serve(app);
+
+    const mockCtx = createMockExecutionCtx();
+    await adapter.fetchHandler!(
+      new Request('http://test/'),
+      {},
+      mockCtx as any
+    );
+
+    const executionCtx = app.calls[0].executionCtx;
+    expect(typeof executionCtx.waitUntil).toBe('function');
+
+    const marker = Promise.resolve('usage-event');
+    executionCtx.waitUntil(marker);
+    expect(mockCtx.waitUntilPromises).toContain(marker);
+
+    executionCtx.passThroughOnException();
+  });
+
+  it('defaults env to an empty object and executionCtx to undefined when omitted', async () => {
+    adapter = new WorkerdProdAdapter();
+    const app = createRecordingMockApp();
+    await adapter.serve(app);
+
+    await adapter.fetchHandler!(new Request('http://test/'));
+
+    expect(app.calls[0].env).toEqual({});
+    expect(app.calls[0].executionCtx).toBeUndefined();
+  });
+
   it('close clears fetchHandler', async () => {
     adapter = new WorkerdProdAdapter({ passthrough: true });
     await adapter.serve(createMockApp());
@@ -78,24 +162,27 @@ describe('WorkerdProdAdapter', () => {
     expect(adapter.fetchHandler).toBeNull();
   });
 
-  describeIfWorkerd('workerd mode (addEventListener)', () => {
-    it('serve registers fetch listener', async () => {
-      adapter = new WorkerdProdAdapter();
-      const app = createMockApp();
+  describeIfWorkerd(
+    'workerd mode (addEventListener, passthrough: false)',
+    () => {
+      it('serve registers fetch listener', async () => {
+        adapter = new WorkerdProdAdapter({ passthrough: false });
+        const app = createMockApp();
 
-      const servePromise = adapter.serve(app);
-      await expect(servePromise).resolves.toBeUndefined();
+        const servePromise = adapter.serve(app);
+        await expect(servePromise).resolves.toBeUndefined();
 
-      expect(adapter.fetchHandler).not.toBeNull();
-    });
+        expect(adapter.fetchHandler).not.toBeNull();
+      });
 
-    it('close removes fetch listener', async () => {
-      adapter = new WorkerdProdAdapter();
-      await adapter.serve(createMockApp());
+      it('close removes fetch listener', async () => {
+        adapter = new WorkerdProdAdapter({ passthrough: false });
+        await adapter.serve(createMockApp());
 
-      await adapter.close();
+        await adapter.close();
 
-      expect(adapter.fetchHandler).toBeNull();
-    });
-  });
+        expect(adapter.fetchHandler).toBeNull();
+      });
+    }
+  );
 });

--- a/packages/platform/runtime/src/adapters/bun/dev.ts
+++ b/packages/platform/runtime/src/adapters/bun/dev.ts
@@ -27,6 +27,7 @@ import { BunWatcher } from './watcher.js';
 import { startBunServer, type BunServerHandle } from './server.js';
 import { loadBunEnvFiles } from './env.js';
 import { Futon } from '@rasenganjs/futon';
+import { createWaitUntilStub } from '../wait-until-stub.js';
 
 /** Minimal interface for a Bun child subprocess. */
 interface BunChildSubprocess {
@@ -111,11 +112,15 @@ export class BunDevAdapter implements RuntimeAdapter {
 
   /** Start the in-process HTTP server via Bun.serve(). */
   private startServer(app: Futon): void {
-    this.serverHandle = startBunServer((request) => app.fetch(request), {
-      port: this.options.port,
-      host: this.options.host,
-      onListening: this.serveOptions.onListening,
-      websocket: this.serveOptions.websocket,
-    });
+    const executionCtx = createWaitUntilStub();
+    this.serverHandle = startBunServer(
+      (request) => app.fetch(request, { executionCtx }),
+      {
+        port: this.options.port,
+        host: this.options.host,
+        onListening: this.serveOptions.onListening,
+        websocket: this.serveOptions.websocket,
+      }
+    );
   }
 }

--- a/packages/platform/runtime/src/adapters/bun/prod.ts
+++ b/packages/platform/runtime/src/adapters/bun/prod.ts
@@ -20,6 +20,7 @@ import type { RuntimeAdapter, ServeOptions, Assets } from '../../types.js';
 
 import { startBunServer, type BunServerHandle } from './server.js';
 import { loadBunEnvFiles } from './env.js';
+import { createWaitUntilStub } from '../wait-until-stub.js';
 import { join, resolve, relative } from 'node:path';
 import { readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
@@ -103,12 +104,16 @@ export class BunProdAdapter implements RuntimeAdapter {
 
     await app.init();
 
-    this.serverHandle = startBunServer((request) => app.fetch(request), {
-      port: this.options.port,
-      host: this.options.host,
-      onListening: options?.onListening,
-      websocket: options?.websocket,
-    });
+    const executionCtx = createWaitUntilStub();
+    this.serverHandle = startBunServer(
+      (request) => app.fetch(request, { executionCtx }),
+      {
+        port: this.options.port,
+        host: this.options.host,
+        onListening: options?.onListening,
+        websocket: options?.websocket,
+      }
+    );
 
     return this.serverHandle.ready;
   }

--- a/packages/platform/runtime/src/adapters/node/dev.ts
+++ b/packages/platform/runtime/src/adapters/node/dev.ts
@@ -29,6 +29,7 @@ import { NodeAssets } from './assets.js';
 import { NodeWatcher } from './watcher.js';
 import { startNodeServer, type NodeServerHandle } from './server.js';
 import { loadNodeEnvFiles } from './env.js';
+import { createWaitUntilStub } from '../wait-until-stub.js';
 
 export interface NodeDevAdapterOptions {
   port?: number;
@@ -124,11 +125,15 @@ export class NodeDevAdapter implements RuntimeAdapter {
 
   /** Start the in-process HTTP server. */
   private startServer(app: any): void {
-    this.serverHandle = startNodeServer((request) => app.fetch(request), {
-      port: this.options.port,
-      host: this.options.host,
-      onListening: this.serveOptions.onListening,
-      websocket: this.serveOptions.websocket,
-    });
+    const executionCtx = createWaitUntilStub();
+    this.serverHandle = startNodeServer(
+      (request) => app.fetch(request, { executionCtx }),
+      {
+        port: this.options.port,
+        host: this.options.host,
+        onListening: this.serveOptions.onListening,
+        websocket: this.serveOptions.websocket,
+      }
+    );
   }
 }

--- a/packages/platform/runtime/src/adapters/node/prod.ts
+++ b/packages/platform/runtime/src/adapters/node/prod.ts
@@ -24,6 +24,7 @@ import type { RuntimeAdapter, ServeOptions, Assets } from '../../types.js';
 
 import { startNodeServer, type NodeServerHandle } from './server.js';
 import { loadNodeEnvFiles } from './env.js';
+import { createWaitUntilStub } from '../wait-until-stub.js';
 import { join, resolve, relative } from 'node:path';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import type { Dirent } from 'node:fs';
@@ -118,12 +119,16 @@ export class NodeProdAdapter implements RuntimeAdapter {
 
     await app.init();
 
-    this.serverHandle = startNodeServer((request) => app.fetch(request), {
-      port: this.options.port,
-      host: this.options.host,
-      onListening: options?.onListening,
-      websocket: options?.websocket,
-    });
+    const executionCtx = createWaitUntilStub();
+    this.serverHandle = startNodeServer(
+      (request) => app.fetch(request, { executionCtx }),
+      {
+        port: this.options.port,
+        host: this.options.host,
+        onListening: options?.onListening,
+        websocket: options?.websocket,
+      }
+    );
 
     return this.serverHandle.ready;
   }

--- a/packages/platform/runtime/src/adapters/wait-until-stub.ts
+++ b/packages/platform/runtime/src/adapters/wait-until-stub.ts
@@ -1,0 +1,16 @@
+/**
+ * Fire-and-forget `waitUntil` stub for runtimes with no real
+ * `ExecutionContext` (Node, Bun). Keeps `ctx.runtime.executionCtx?.waitUntil(...)`
+ * callable uniformly across every adapter (RFC-0013) — a rejected
+ * promise is caught and logged instead of becoming an unhandled
+ * rejection, since there is no platform to report it to.
+ */
+export function createWaitUntilStub() {
+  return {
+    waitUntil(promise: Promise<unknown>): void {
+      promise.catch((err) => {
+        console.error('[futon] waitUntil rejected:', err);
+      });
+    },
+  };
+}

--- a/packages/platform/runtime/src/adapters/workerd/prod.ts
+++ b/packages/platform/runtime/src/adapters/workerd/prod.ts
@@ -8,9 +8,21 @@
  *
  * ## How it works
  *
- * - `serve(app)` registers the Futon's fetch handler via
- *   `self.addEventListener('fetch', ...)`, the standard service-worker
- *   pattern supported by workerd.
+ * - Defaults to **Module Worker** format: `serve(app)` builds
+ *   `fetchHandler`, a `(request, env, ctx) => Promise<Response>`
+ *   function meant for `export default { fetch: adapter.fetchHandler }`.
+ *   `env` (bindings: D1, R2, KV, service bindings, secrets) and `ctx`
+ *   (`ExecutionContext.waitUntil`/`passThroughOnException`) are both
+ *   forwarded into the Futon's `RuntimeContext` on every request
+ *   (RFC-0013) — read them via `ctx.runtime.env` / `ctx.runtime.executionCtx`
+ *   inside handlers and middleware.
+ * - Set `passthrough: false` to instead register via the legacy
+ *   **Service Worker** format (`self.addEventListener('fetch', ...)`).
+ *   That format predates bindings-as-arguments and workerd never
+ *   passes `env` to it — `ctx.runtime.env` stays empty in this mode,
+ *   only `ctx.runtime.executionCtx.waitUntil` is available (backed by
+ *   `FetchEvent.waitUntil`). Use Module Worker format if the app reads
+ *   any binding.
  * - Assets are **no-ops** — workerd has no local filesystem at runtime.
  *   To serve static assets, use Workers KV, R2, or a build-time upload.
  * - `watch()` is **not implemented** — no file watcher in production
@@ -22,18 +34,10 @@
  * import { WorkerdProdAdapter } from "@rasenganjs/runtime/adapters/workerd";
  *
  * const app = new Futon();
- * app.get("/hello", () => new Response("Hello from the edge!"));
+ * app.get("/hello", (ctx) => new Response(`Hello, DB is ${ctx.runtime.env?.DB}`));
  *
  * const adapter = new WorkerdProdAdapter();
- * adapter.serve(app);
- * ```
- *
- * ES modules format (workers.dev / custom build):
- * ```ts
- * import { WorkerdProdAdapter } from "@rasenganjs/runtime/adapters/workerd";
- * import app from "./app";
- *
- * const adapter = new WorkerdProdAdapter({ passthrough: true });
+ * await adapter.serve(app);
  * export default { fetch: adapter.fetchHandler };
  * ```
  */
@@ -46,9 +50,12 @@ export interface WorkerdProdAdapterOptions {
   /** Host (ignored by workerd — exists for type compatibility). */
   host?: string;
   /**
-   * Pass the application's fetch handler as a module-level export
-   * for the ES modules format.  When `false` (default), the adapter
-   * registers via `self.addEventListener('fetch', ...)` instead.
+   * Expose the application's fetch handler as a module-level export
+   * for the ES modules (Module Worker) format. Defaults to `true`
+   * (RFC-0013) since it is the only format workerd passes bindings
+   * to. Set to `false` to fall back to the legacy Service Worker
+   * format (`self.addEventListener('fetch', ...)`), which never
+   * receives `env` — see the class doc comment.
    */
   passthrough?: boolean;
 }
@@ -58,11 +65,21 @@ export class WorkerdProdAdapter implements RuntimeAdapter {
 
   /**
    * The raw fetch handler, suitable for `export default { fetch }`.
-   * Only available after `serve()` has been called.
+   * Only available after `serve()` has been called. Matches workerd's
+   * own Module Worker signature, `env` and `ctx` are forwarded into
+   * the Futon's `RuntimeContext` (RFC-0013).
    */
-  fetchHandler: ((request: Request) => Promise<Response>) | null = null;
+  fetchHandler:
+    | ((
+        request: Request,
+        env?: unknown,
+        ctx?: ExecutionContext
+      ) => Promise<Response>)
+    | null = null;
 
   constructor(private options: WorkerdProdAdapterOptions = {}) {
+    this.options.passthrough = this.options.passthrough ?? true;
+
     // workerd has no local filesystem at runtime.
     // Assets can be served via KV / R2 / D1 at the Futon layer.
     this.assets = {
@@ -94,7 +111,20 @@ export class WorkerdProdAdapter implements RuntimeAdapter {
     await app.init();
 
     this.app = app;
-    this.fetchHandler = (request: Request) => app.fetch(request);
+    this.fetchHandler = (
+      request: Request,
+      env?: unknown,
+      ctx?: ExecutionContext
+    ) =>
+      app.fetch(request, {
+        env: (env ?? {}) as Record<string, unknown>,
+        executionCtx: ctx
+          ? {
+              waitUntil: (promise: Promise<unknown>) => ctx.waitUntil(promise),
+              passThroughOnException: () => ctx.passThroughOnException(),
+            }
+          : undefined,
+      });
 
     if (this.options.passthrough) {
       // Caller will export fetchHandler manually via `export default`.
@@ -137,11 +167,20 @@ export class WorkerdProdAdapter implements RuntimeAdapter {
   /**
    * Handle a FetchEvent by delegating to the Futon.
    * Returns a 503 response if the server has been closed.
+   *
+   * Service Worker format has no `env` argument to forward (see the
+   * class doc comment) — only `executionCtx.waitUntil` is wired here,
+   * backed by `FetchEvent.waitUntil`.
    */
   private async handleEvent(event: FetchEvent): Promise<Response> {
     if (this.closed || !this.app) {
       return new Response('Server closed', { status: 503 });
     }
-    return this.app.fetch(event.request);
+    return this.app.fetch(event.request, {
+      executionCtx: {
+        waitUntil: (promise: Promise<unknown>) =>
+          event.waitUntil(promise.then(() => undefined)),
+      },
+    });
   }
 }

--- a/packages/platform/runtime/src/adapters/workerd/types.d.ts
+++ b/packages/platform/runtime/src/adapters/workerd/types.d.ts
@@ -30,3 +30,14 @@ interface ServiceWorkerGlobalScope {
 
 /** The global `self` object in Worker environments. */
 declare var self: ServiceWorkerGlobalScope;
+
+/**
+ * The `ExecutionContext` passed as the third argument to a Module
+ * Worker's exported `fetch(request, env, ctx)` handler (RFC-0013).
+ * Declared ambiently, same rationale as `FetchEvent` above: no
+ * dependency on `@cloudflare/workers-types`.
+ */
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+}

--- a/proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md
+++ b/proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md
@@ -1,6 +1,6 @@
 # RFC 0013 - Workers Bindings and ExecutionContext for Futon on Workerd
 
-**Status:** Draft
+**Status:** Implemented (Phase 1: 2026-08-15, Phase 2: 2026-08-15)
 **Author:** Rasengan.js Core Team
 **Date:** 2026-08-15
 
@@ -224,3 +224,15 @@ The adapter side does not need its own generic parameter. `WorkerdProdAdapter.se
 
 - Should Phase 2's `Env` generic eventually also cover `state` (Hono's `Variables` slot), or stay bindings-only indefinitely? Left open, not blocking Phase 1 or Phase 2 as scoped here.
 - Should `@rasenganjs/cloudflare` (RFC-0009) or a future BaaS-side CLI own generating a project's `Bindings` type from `wrangler.jsonc` or a schema file, once Phase 2 ships? Noted as a natural follow-up, not decided here.
+
+---
+
+# As implemented
+
+Both phases shipped 2026-08-15, on branch `feat/futon-workerd-bindings`. Two real deviations from this RFC's original sketch, both found while implementing, neither changing the outcome for a caller:
+
+**`Env` is the last type parameter on `Context`, not conceptually "first."** A grep across the repo before touching the signature found a real, existing 3-positional-argument call site: `packages/framework/rasengan-server/src/router/index.ts`'s `Context<InferBody<S>, InferParams<S>, InferQuery<S>>`. Inserting `Env` anywhere before the existing `Body, Params, Query` triplet would have silently rebound that call site's arguments to the wrong parameters, a breaking change this RFC's Goals explicitly rule out ("Zero public API change" in spirit, no existing 3-arg `Context<...>` caller should need to change). `Context<Body = any, Params = Record<string, string>, Query = QueryParams, Env = Record<string, unknown>>` keeps that call site compiling unchanged; `RuntimeContext<Env>` (single parameter) and the new `Handler<Env, Params>` / `ErrorHandler<Env>` types had no such constraint and use `Env` as their first parameter.
+
+**`Router` and `Middleware`'s internal call sites stay untyped for `Env`, only `Futon`'s own `get`/`post`/`put`/`patch`/`delete`/`head`/`options`/`use`/`notFound`/`fallback`/`onError` are typed.** Making `Router<Env>` generic (and `SubRouter<Env> extends Router<Env>`, and `RouteEntry<Env>`, and `compose()`) to thread `Env` all the way into the radix-tree dispatch internals was judged out of proportion to the goal: that machinery has no code path that reads `ctx.runtime.env` itself, only user handlers do. Instead, `Futon<Env>`'s public methods accept `Handler<Env>`/`Middleware<Env>`-typed callbacks and cast once at the boundary into the router's untyped internals (`handler as unknown as (ctx: Context) => Promise<Response>`). This is sound because `Env` only changes what TypeScript infers for `ctx.runtime.env`, never the actual object at runtime: the same value flows through regardless of which type parameter labeled it at any given point. One consequence, called out in a code comment on the `Futon` class itself: routes registered through `app.group()` on the raw `Router` returned by `getRouter()` do not get a typed `ctx.runtime.env` (they fall back to `Record<string, unknown>`), only routes registered directly through `Futon`'s own methods do. Left as a known, explicit gap rather than a silent one, closing it is the natural next step if `group()`-registered routes turn out to need typed bindings too, not attempted here.
+
+**Verification:** `@rasenganjs/futon` 347/347 tests (2 new for Phase 1's `env`/`executionCtx` on `Futon.fetch()`, 1 new proving Phase 2's typed `ctx.runtime.env` compiles with zero casts inside a handler). `@rasenganjs/runtime` 111/151 (40 skipped, Bun/Workerd-gated, not runnable under plain Node/vitest), 7 new tests across the four Node/Bun adapters and Workerd's `WorkerdProdAdapter` covering `env`/`executionCtx` forwarding and the new `passthrough: true` default. `@rasenganjs/server` (downstream consumer, including the `Context<...>` 3-arg call site above) 118/118 tests unchanged, builds clean. `tsc --noEmit` on all three packages shows only errors confirmed pre-existing on the `docs` base branch via `git stash` comparison, no new errors introduced by either phase.

--- a/proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md
+++ b/proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md
@@ -1,0 +1,226 @@
+# RFC 0013 - Workers Bindings and ExecutionContext for Futon on Workerd
+
+**Status:** Draft
+**Author:** Rasengan.js Core Team
+**Date:** 2026-08-15
+
+## Executive Summary
+
+`WorkerdProdAdapter.fetchHandler` currently forwards only `request` to `Futon.fetch()`. Cloudflare calls an exported Workers handler with three arguments, `fetch(request, env, ctx)`, so `env` (the bindings object: D1, R2, KV, service bindings, secrets) and `ctx` (`ExecutionContext`, `waitUntil`/`passThroughOnException`) are silently dropped today. A Futon app deployed on workerd cannot currently read a single binding.
+
+`Futon.fetch(request, runtime: RuntimeContext)` already has a slot built for exactly this, `RuntimeContext.env`, but it is typed `Record<string, string>`, which fits `process.env` and not a live binding object like a `D1Database` instance. `RuntimeContext` also has no concept of `ExecutionContext` at all, so `ctx.waitUntil(...)` (needed for fire-and-forget work like emitting usage-metering events without delaying the response) has nowhere to live.
+
+This RFC closes both gaps in two phases: Phase 1 wires the adapter correctly and widens the existing types just enough to be functionally correct (untyped `unknown` bindings). Phase 2 makes `Env` a first-class generic threaded through `Context`/`Futon`/`Handler`, the same shape Hono exposes as `c.env`, so a project can declare its own `Bindings` type once and get full autocomplete everywhere `ctx.runtime.env` is read.
+
+---
+
+# Motivation
+
+## The adapter drops two of three arguments Cloudflare gives it
+
+```ts
+// packages/platform/runtime/src/adapters/workerd/prod.ts (current)
+this.fetchHandler = (request: Request) => app.fetch(request);
+```
+
+and the service-worker path:
+
+```ts
+private async handleEvent(event: FetchEvent): Promise<Response> {
+  if (this.closed || !this.app) return new Response('Server closed', { status: 503 });
+  return this.app.fetch(event.request);
+}
+```
+
+Neither path ever reads `env` or `ctx`. Every binding declared in a deployed script's metadata (the exact mechanism confirmed against Cloudflare's own `workers-for-platforms-example` reference project, where bindings are injected per-script at upload time) is unreachable from inside a Futon handler.
+
+## `RuntimeContext.env` is typed for the wrong shape
+
+```ts
+// packages/framework/futon/src/context/types.ts, line 20
+export interface RuntimeContext {
+  env?: Record<string, string>;
+  ...
+}
+```
+
+A `D1Database`, an `R2Bucket`, a `KVNamespace`, a Workers-for-Platforms dispatcher binding, none of these are strings. Even after Phase 1's adapter fix, this type would reject or silently mistype every real binding.
+
+## `ExecutionContext` has no home in `Context` at all
+
+The Router Worker sketched earlier in this project's architecture work needs `ctx.waitUntil(...)` to emit a usage-metering event without delaying the response to the caller. `RuntimeContext` has no field for this today, on any adapter, not just Workerd.
+
+## The Service Worker format cannot carry bindings by design, not by bug
+
+Cloudflare Workers has two export shapes. The Service Worker format (`addEventListener('fetch', ...)`, `WorkerdProdAdapter`'s current default) predates bindings-as-arguments and never receives `env` as a function parameter. The Module Worker format (`export default { fetch(request, env, ctx) }`, `WorkerdProdAdapter`'s `passthrough: true` mode) is the only shape that receives `env` at all. This means Phase 1's fix is only reachable through `passthrough: true`, fixing the default `addEventListener` path is not an option because the platform itself does not pass bindings that way.
+
+This is not a new problem this RFC introduces. RFC-0009 (`@rasenganjs/cloudflare`) already independently converged on `new WorkerdProdAdapter({ passthrough: true })` for its generated Worker entry point (`proposals/RFC-0009-Cloudflare-Workers-Adapter.md`, "Detailed Design" §3), and separately describes `WorkerdProdAdapter` as "a solved problem; nothing here needs to change" in its Motivation section. Both are consistent: RFC-0009's SSR use case never reads a binding, so the gap this RFC closes was invisible to it. This RFC does not revisit RFC-0009's scope, it closes the gap RFC-0009 didn't need to exercise.
+
+---
+
+# Goals
+
+- `WorkerdProdAdapter` forwards `env` and `ctx` from workerd into Futon's `RuntimeContext` on every request, in both `passthrough` and service-worker registration paths (the latter documented as bindings-incapable rather than silently broken, see Non-goals).
+- `passthrough: true` becomes the documented, recommended mode for any Futon app that needs bindings, since it is the only mode workerd supports for this.
+- `RuntimeContext.env` accepts arbitrary binding values, not just strings, without breaking existing Node/Bun consumers that only ever put strings in it.
+- `ctx.waitUntil(...)` (and `passThroughOnException()`) works uniformly across Node, Bun, and Workerd, backed by the real `ExecutionContext` on Workerd and a fire-and-forget stub elsewhere.
+- Phase 2 (opt-in, additive): `Env` becomes a generic parameter on `Context`, `Futon`, and the route handler types, so `new Futon<Bindings>()` gives `ctx.runtime.env` full autocomplete, matching Hono's `c.env` ergonomics.
+
+## Non-goals
+
+- Making the Service Worker (`addEventListener`) registration path bindings-capable. It cannot be, on any Workers project, by platform design. This RFC documents the limitation and steers users to `passthrough: true` instead of trying to work around it.
+- Generating a project's `Bindings` type automatically from `wrangler.jsonc` (the equivalent of `wrangler types`) or from a BaaS project's schema. Real, useful, explicitly out of scope for this RFC, a natural follow-up once Phase 2 ships.
+- Changing anything about Node/Bun request handling beyond adding the `waitUntil` stub. Their adapters already have no bindings concept and none is being added.
+- Retrofitting every existing Futon app to declare a typed `Bindings` type. Phase 2's default (`Env = Record<string, unknown>`) keeps `new Futon()` compiling unchanged.
+
+---
+
+# Detailed design
+
+## Phase 1 - runtime wiring (non-generic, ships first)
+
+**`RuntimeContext` and a new `ExecutionContext` type**, `packages/framework/futon/src/context/types.ts`:
+
+```ts
+export interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException?(): void;
+}
+
+export interface RuntimeContext {
+  env?: Record<string, unknown>; // widened from Record<string, string>
+  executionCtx?: ExecutionContext; // new
+  server?: ServerInfo;
+  assets?: Assets;
+}
+```
+
+**`WorkerdProdAdapter`**, `packages/platform/runtime/src/adapters/workerd/prod.ts`:
+
+```ts
+this.fetchHandler = (
+  request: Request,
+  env?: unknown,
+  ctx?: WorkerdExecutionContext
+) =>
+  app.fetch(request, {
+    env: (env ?? {}) as Record<string, unknown>,
+    executionCtx: ctx
+      ? {
+          waitUntil: (p) => ctx.waitUntil(p),
+          passThroughOnException: () => ctx.passThroughOnException?.(),
+        }
+      : undefined,
+  });
+```
+
+The service-worker path (`handleEvent`) keeps working exactly as it does today, since `FetchEvent` has its own `waitUntil`/`respondWith` and no `env` to forward, but its doc comment gets an explicit note: bindings are not available here, use `passthrough: true` if the app reads `ctx.runtime.env`.
+
+**`passthrough` becomes the default** (`WorkerdProdAdapterOptions.passthrough` default flips from `false` to `true`). This is the one behavior change existing consumers of `WorkerdProdAdapter` will observe, see "Breaking change and migration."
+
+**Node/Bun adapters** gain the same `executionCtx` field, backed by a stub:
+
+```ts
+executionCtx: {
+  waitUntil: (p) => { p.catch((err) => console.error('[futon] waitUntil rejected:', err)); },
+}
+```
+
+so `ctx.waitUntil(...)` is safe to call from portable middleware regardless of which adapter is running underneath.
+
+## Phase 2 - typed `Env` generic (additive, opt-in)
+
+Mirrors Hono's `c.env`, but flatter: Hono splits its generic into `{ Bindings, Variables }`; this RFC proposes only a `Bindings`-equivalent (`Env`), since Futon's `state` bag (the `Variables`-equivalent) is already untyped and orthogonal, adding it to the same generic is a separate, later decision, not bundled here.
+
+```ts
+// context/types.ts
+export interface RuntimeContext<Env = Record<string, unknown>> {
+  env?: Env;
+  executionCtx?: ExecutionContext;
+  server?: ServerInfo;
+  assets?: Assets;
+}
+
+export interface Context<
+  Env = Record<string, unknown>,
+  Body = any,
+  Params = Record<string, string>,
+  Query = QueryParams,
+> {
+  ...
+  runtime: RuntimeContext<Env>;
+  ...
+}
+```
+
+```ts
+// app/index.ts
+export class Futon<Env = Record<string, unknown>> {
+  async fetch(request: Request, runtime: RuntimeContext<Env> = {}): Promise<Response> { ... }
+
+  get<Path extends string>(path: Path, handler: Handler<Env, Path>): this { ... }
+  post<Path extends string>(path: Path, handler: Handler<Env, Path>): this { ... }
+  // same pattern for put/patch/delete/use/etc.
+}
+```
+
+```ts
+// types.ts
+export type Handler<
+  Env = Record<string, unknown>,
+  Params = Record<string, string>,
+> = (ctx: Context<Env, any, Params>) => Response | Promise<Response>;
+```
+
+Every default is `Record<string, unknown>`, so `new Futon()` and untyped handlers keep compiling exactly as they do today. A project that wants typed bindings opts in once:
+
+```ts
+type Bindings = {
+  DB: D1Database;
+  BUCKET: R2Bucket;
+};
+
+const app = new Futon<Bindings>();
+
+app.get('/products', async (ctx) => {
+  const rows = await ctx.runtime.env.DB.prepare('select * from products').all();
+  return ctx.res.json(rows);
+});
+```
+
+The adapter side does not need its own generic parameter. `WorkerdProdAdapter.serve(app)` can stay as written today, since `app: Futon<Env>` already carries `Env`, TypeScript infers it at the call site through `app.fetch`'s own signature.
+
+---
+
+# Alternatives considered
+
+**Keep the Service Worker format as the default and only document the limitation.** Rejected. It defeats this RFC's stated goal (bindings actually reachable from a deployed Futon app) for the common case, forcing every caller to remember to pass `passthrough: true` themselves.
+
+**Hono's two-slot `{ Bindings, Variables }` Env shape, adopted wholesale.** Rejected as the primary design, noted as a future option. Futon's `state` bag already exists, independently typed (`Record<string, unknown>`), and works today. Bundling it into the same generic as bindings is a bigger, separate API change with its own tradeoffs (every `ctx.set`/`ctx.get` call site would need updating to stay type-safe) that this RFC does not need in order to close the bindings gap.
+
+**Make `WorkerdProdAdapter` itself generic (`WorkerdProdAdapter<Env>`).** Rejected. Adds a type parameter that has to be repeated at the adapter construction site for no benefit, since `serve(app)` already receives a fully-typed `app` and TypeScript infers through it.
+
+---
+
+# Breaking change and migration
+
+**`WorkerdProdAdapterOptions.passthrough` default flips from `false` to `true`.** Anyone constructing `new WorkerdProdAdapter()` today without an explicit `passthrough` option and relying on the `addEventListener` registration behavior will see a change: they now need `export default { fetch: adapter.fetchHandler }` in their entry file instead of relying on the adapter registering the listener itself. Given `@rasenganjs/runtime` is pre-1.0 (matches the versioning stance already taken in RFC-0012) and RFC-0009's own generated Worker entry already hardcodes `passthrough: true`, the only realistic caller affected is a hand-rolled workerd entry point outside `@rasenganjs/cloudflare`. Documented in the CHANGELOG as a beta breaking change, not a major version bump.
+
+**`RuntimeContext.env` type widen from `Record<string, string>` to `Record<string, unknown>` (Phase 1) then to a generic `Env` (Phase 2).** Not breaking for read access (`unknown` is a superset of `string`), existing code that assumed string values without narrowing will need a type guard or cast, which is the correct behavior for code that is about to receive non-string bindings anyway.
+
+---
+
+# Testing
+
+- `WorkerdProdAdapter.fetchHandler(request, env, ctx)`: `env` and `executionCtx.waitUntil` both reach the handler inside `Futon.fetch()`, verified with a mock `env` object and a mock `ExecutionContext`.
+- `passthrough: true` is the default: constructing `new WorkerdProdAdapter()` with no options exposes `fetchHandler` without requiring the option.
+- Node and Bun adapters: `ctx.waitUntil(promise)` does not throw and does not block the response; a rejected promise passed to `waitUntil` is caught and logged, not thrown.
+- Phase 2: a `Futon<Bindings>()` instance's route handler receives `ctx.runtime.env` typed as `Bindings`, verified with a `tsc`-level type test (no `any` leak), alongside a runtime test that the actual bound value passed through the adapter is the exact object handed to `env`.
+- Regression: existing Node/Bun `RuntimeContext.env` consumers (currently string-only) keep passing unchanged.
+
+---
+
+# Open questions
+
+- Should Phase 2's `Env` generic eventually also cover `state` (Hono's `Variables` slot), or stay bindings-only indefinitely? Left open, not blocking Phase 1 or Phase 2 as scoped here.
+- Should `@rasenganjs/cloudflare` (RFC-0009) or a future BaaS-side CLI own generating a project's `Bindings` type from `wrangler.jsonc` or a schema file, once Phase 2 ships? Noted as a natural follow-up, not decided here.


### PR DESCRIPTION
## Related Issue

No linked issue. Design and rationale are recorded in `proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md`.

## Type of Change

- [ ] Documentation (Updates to README, API docs, or comments)
- [ ] Bug Fix (Non-breaking fix for an issue)
- [ ] Performance (Optimizations for faster execution)
- [x] Feature (New functionality without breaking changes)
- [ ] Refactor (Code improvements without changing behavior)
- [ ] Chore (Build process, tooling, dependencies)
- [x] Breaking Change (Modifications that impact existing usage)

## Description

`WorkerdProdAdapter.fetchHandler` only forwarded `request` to `Futon.fetch()`. Cloudflare calls an exported Workers handler with three arguments, `fetch(request, env, ctx)`, so `env` (bindings: D1, R2, KV, service bindings, secrets) and `ctx` (`ExecutionContext`, `waitUntil`/`passThroughOnException`) were silently dropped. A Futon app deployed on Workerd could not read a single binding.

**Phase 1** wires `env` and `ctx` through `WorkerdProdAdapter` into Futon's `RuntimeContext`, widens `RuntimeContext.env` from `Record<string, string>` to `Record<string, unknown>` since a binding is a live object, not a string, and adds `RuntimeContext.executionCtx` for fire-and-forget work. `passthrough` now defaults to `true`, since the legacy Service Worker registration format never receives `env` from Workerd by platform design, only the Module Worker format does. Node and Bun adapters gain the same `executionCtx` via a shared logging stub, so `ctx.runtime.executionCtx?.waitUntil(...)` is safe to call on every runtime.

**Phase 2** adds `Env` as a generic parameter on `Context`, `Futon`, and the new `Handler`/`ErrorHandler`/`Middleware` types, defaulting to `Record<string, unknown>` so existing untyped code compiles unchanged. A project declares its own `Bindings` type once and passes it to `new Futon<Bindings>()` to get full autocomplete on `ctx.runtime.env` in every handler and middleware, matching Hono's `c.env` ergonomics. `Env` is placed last in `Context`'s generic parameter list, not first, to keep an existing 3 argument `Context<Body, Params, Query>` call site in `@rasenganjs/server`'s router compiling unchanged. `Router`/`Middleware` internals stay untyped for `Env`, only `Futon`'s own route and middleware registration methods are typed, with a documented, explicit gap for routes registered through `app.group()`.

## Screenshots / Demos (if applicable)

N/A, backend library change with no UI surface.

## Checklist

- [ ] I have linked a related issue or discussion.
- [x] I have updated documentation if needed.
- [ ] I have tested the changes in a real project.
- [x] I have added tests or confirmed that existing tests pass.

## Additional Notes

`@rasenganjs/futon`: 348/348 tests passing (2 new for env/executionCtx forwarding, 1 new proving the typed `Bindings` example compiles with zero casts inside a handler). `@rasenganjs/runtime`: 111/151 passing, 40 skipped (Bun and Workerd specific tests, not runnable under plain Node/vitest), 7 new tests covering env/executionCtx forwarding and the new `passthrough: true` default across all four Node/Bun adapters and `WorkerdProdAdapter`. `@rasenganjs/server`, a downstream consumer including the 3 argument `Context<...>` call site mentioned above, still passes 118/118 with no changes required. `tsc --noEmit` on all three packages shows only pre-existing errors, confirmed via `git stash` comparison against the base branch, no new errors introduced.

Marked as a breaking change narrowly: `WorkerdProdAdapterOptions.passthrough`'s default flips from `false` to `true`. Every real caller in this repo (`@rasenganjs/cloudflare`, `rasengan-server`'s generated worker entry) already passes `passthrough: true` explicitly, so this only affects a hand rolled Workerd entry point outside this repo relying on the old default. See "Breaking change and migration" in `proposals/RFC-0013-Futon-Workerd-Bindings-ExecutionContext.md` for details.